### PR TITLE
Feat/03 db kafka - 카탈로그 전체/단건조회, 재고 차감 반영

### DIFF
--- a/src/main/java/com/michelet/catalog/CatalogServiceApplication.java
+++ b/src/main/java/com/michelet/catalog/CatalogServiceApplication.java
@@ -1,5 +1,7 @@
 package com.michelet.catalog;
 
+import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
+
 import com.michelet.common.config.CommonAutoConfiguration;
 import com.michelet.common.exception.GlobalExceptionHandler;
 import org.springframework.boot.SpringApplication;
@@ -8,6 +10,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
 import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerAutoConfiguration;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.web.config.EnableSpringDataWebSupport;
 
 // 공통 모듈(common)에서 가져온 JPA 때문에 발생하는 불필요한 RDBMS 자동 설정 비활성화
 @SpringBootApplication(exclude = {
@@ -16,11 +19,12 @@ import org.springframework.context.annotation.Import;
     HibernateJpaAutoConfiguration.class,
     CommonAutoConfiguration.class // 공통 모듈의 자동 설정(JPA Auditing 포함) 비활성화
 })
+@EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
 @Import(GlobalExceptionHandler.class) // 공통 모듈에서 필요한 전역 예외 처리기만 수동으로 등록
 public class CatalogServiceApplication {
 
-	public static void main(String[] args) {
-		SpringApplication.run(CatalogServiceApplication.class, args);
-	}
+    public static void main(String[] args) {
+        SpringApplication.run(CatalogServiceApplication.class, args);
+    }
 
 }

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -18,11 +18,9 @@ public class ProductViewCommandService {
      * 재고 예약 이벤트를 처리하여 MongoDB 데이터를 갱신함
      */
     public void applyStockReservedEvent(StockReservedEvent event) {
-        if (event == null || event.optionId() == null ||
-            event.totalQuantity() == null || event.totalQuantity() < 0 ||
-            event.currentDailyStock() == null || event.currentDailyStock() < 0) {
-            log.warn("유효하지 않은 재고 이벤트 페이로드 무시됨: {}", event);
-            return;
+        // 이벤트 객체 자체가 null인지 가장 먼저 확인
+        if (event == null) {
+            throw new IllegalArgumentException("이벤트 페이로드가 null입니다.");
         }
 
         log.info("재고 차감 이벤트 수신: optionId={}, total={}, daily={}",

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -18,6 +18,13 @@ public class ProductViewCommandService {
      * 재고 예약 이벤트를 처리하여 MongoDB 데이터를 갱신함
      */
     public void applyStockReservedEvent(StockReservedEvent event) {
+        if (event == null || event.optionId() == null ||
+            event.totalQuantity() == null || event.totalQuantity() < 0 ||
+            event.currentDailyStock() == null || event.currentDailyStock() < 0) {
+            log.warn("유효하지 않은 재고 이벤트 페이로드 무시됨: {}", event);
+            return;
+        }
+
         log.info("재고 차감 이벤트 수신: optionId={}, total={}, daily={}",
             event.optionId(), event.totalQuantity(), event.currentDailyStock());
 

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -1,0 +1,35 @@
+package com.michelet.catalog.application;
+
+import com.michelet.catalog.domain.model.ProductView;
+import com.michelet.catalog.domain.repository.ProductViewRepository;
+import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class ProductViewCommandService {
+
+    private final ProductViewRepository productViewRepository;
+
+    /**
+     * 재고 예약 이벤트를 처리하여 MongoDB 데이터를 갱신함
+     */
+    public void applyStockReservedEvent(StockReservedEvent event) {
+        log.info("재고 차감 이벤트 수신: optionId={}, total={}, daily={}",
+            event.optionId(), event.totalQuantity(), event.currentDailyStock());
+
+        // 1. 해당 옵션을 가지고 있는 상품 문서 찾기
+        ProductView productView = productViewRepository.findByOptionsOptionId(event.optionId())
+            .orElseThrow(() -> new IllegalArgumentException("해당 옵션을 가진 상품을 찾을 수 없습니다: " + event.optionId()));
+
+        // 2. 문서 내의 재고 데이터를 업데이트
+        productView.updateStock(event.optionId(), event.totalQuantity(), event.currentDailyStock());
+
+        // 3. MongoDB에 저장 (덮어쓰기)
+        productViewRepository.save(productView);
+        log.info("MongoDB 재고 업데이트 완료: productId={}", productView.getProductId());
+    }
+}

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -1,5 +1,6 @@
 package com.michelet.catalog.application;
 
+import com.michelet.catalog.domain.exception.ProductNotFoundException;
 import com.michelet.catalog.domain.model.ProductView;
 import com.michelet.catalog.domain.repository.ProductViewRepository;
 import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
@@ -28,7 +29,7 @@ public class ProductViewCommandService {
 
         // 1. 해당 옵션을 가지고 있는 상품 문서 찾기
         ProductView productView = productViewRepository.findByOptionsOptionId(event.optionId())
-            .orElseThrow(() -> new IllegalArgumentException("해당 옵션을 가진 상품을 찾을 수 없습니다: " + event.optionId()));
+            .orElseThrow(ProductNotFoundException::new);
 
         // 2. 문서 내의 재고 데이터를 업데이트
         productView.updateStock(event.optionId(), event.totalQuantity(), event.currentDailyStock());

--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -1,0 +1,27 @@
+package com.michelet.catalog.application;
+
+import com.michelet.catalog.domain.repository.ProductViewRepository;
+import com.michelet.catalog.presentation.dto.ProductViewResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductViewQueryService {
+
+    private final ProductViewRepository productViewRepository;
+
+    public Page<ProductViewResponse> getProducts(Pageable pageable) {
+        return productViewRepository.findAll(pageable)
+            .map(ProductViewResponse::from);
+    }
+
+    public ProductViewResponse getProduct(UUID productId) {
+        return productViewRepository.findByProductId(productId)
+            .map(ProductViewResponse::from)
+            .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다. ID: " + productId));
+    }
+}

--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -1,5 +1,6 @@
 package com.michelet.catalog.application;
 
+import com.michelet.catalog.domain.exception.ProductNotFoundException;
 import com.michelet.catalog.domain.repository.ProductViewRepository;
 import com.michelet.catalog.presentation.dto.ProductViewResponse;
 import java.util.UUID;
@@ -20,8 +21,9 @@ public class ProductViewQueryService {
     }
 
     public ProductViewResponse getProduct(UUID productId) {
+        // Application 계층이 Web 계층의 상태 코드를 직접 반환하지 않도록... 순수 도메인 예외를 정의해 던짐
         return productViewRepository.findByProductId(productId)
             .map(ProductViewResponse::from)
-            .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다. ID: " + productId));
+            .orElseThrow(ProductNotFoundException::new);
     }
 }

--- a/src/main/java/com/michelet/catalog/domain/exception/CatalogErrorCode.java
+++ b/src/main/java/com/michelet/catalog/domain/exception/CatalogErrorCode.java
@@ -1,0 +1,16 @@
+package com.michelet.catalog.domain.exception;
+
+import com.michelet.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CatalogErrorCode implements ErrorCode {
+    
+    PRODUCT_NOT_FOUND(404, "PRODUCT_001", "해당 상품을 찾을 수 없습니다.");
+
+    private final int httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/michelet/catalog/domain/exception/ProductNotFoundException.java
+++ b/src/main/java/com/michelet/catalog/domain/exception/ProductNotFoundException.java
@@ -1,0 +1,10 @@
+package com.michelet.catalog.domain.exception;
+
+import com.michelet.common.exception.BusinessException;
+
+public class ProductNotFoundException extends BusinessException {
+
+    public ProductNotFoundException() {
+        super(CatalogErrorCode.PRODUCT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -1,0 +1,114 @@
+package com.michelet.catalog.domain.model;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.Indexed;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+@Document(collection = "p_product_views")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ProductView {
+
+    @Id
+    private String id; // MongoDB의 ObjectId
+
+    @Indexed(unique = true)
+    @Field("product_id")
+    private UUID productId; // PostgreSQL의 상품 ID
+
+    @Indexed
+    @Field("restaurant_id")
+    private UUID restaurantId;
+
+    private String name;
+    private String category;
+    private Map<String, Object> metadata;
+
+    @Field("is_visible")
+    private boolean isVisible;
+
+    private Display display;
+    private List<OptionView> options;
+
+    @Builder
+    private ProductView(UUID productId, UUID restaurantId, String name, String category, Map<String, Object> metadata,
+                        boolean isVisible, Display display, List<OptionView> options) {
+        this.productId = productId;
+        this.restaurantId = restaurantId;
+        this.name = name;
+        this.category = category;
+        this.metadata = metadata;
+        this.isVisible = isVisible;
+        this.display = display;
+        this.options = options;
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class Display {
+        @Field("start_at")
+        private LocalDateTime startAt;
+
+        @Field("end_at")
+        private LocalDateTime endAt;
+
+        public Display(LocalDateTime startAt, LocalDateTime endAt) {
+            this.startAt = startAt;
+            this.endAt = endAt;
+        }
+    }
+
+    @Getter
+    @NoArgsConstructor(access = AccessLevel.PROTECTED)
+    public static class OptionView {
+        @Field("option_id")
+        private UUID optionId;
+
+        private String name;
+
+        @Field("add_price")
+        private BigDecimal addPrice;
+
+        @Field("total_quantity")
+        private Integer totalQuantity;
+
+        @Field("current_daily_stock")
+        private Integer currentDailyStock;
+
+        public OptionView(UUID optionId, String name, BigDecimal addPrice, Integer totalQuantity,
+                          Integer currentDailyStock) {
+            this.optionId = optionId;
+            this.name = name;
+            this.addPrice = addPrice;
+            this.totalQuantity = totalQuantity;
+            this.currentDailyStock = currentDailyStock;
+        }
+    }
+
+    /**
+     * 재고 예약(차감) 이벤트를 수신했을 때 호출되어 옵션의 재고를 갱신함
+     */
+    public void updateStock(UUID targetOptionId, Integer newTotalQuantity, Integer newCurrentDailyStock) {
+        if (this.options == null) {
+            return;
+        }
+
+        for (OptionView option : this.options) {
+            if (option.getOptionId().equals(targetOptionId)) {
+                option.totalQuantity = newTotalQuantity;
+                option.currentDailyStock = newCurrentDailyStock;
+                break;
+            }
+        }
+    }
+}

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -4,17 +4,20 @@ import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.index.CompoundIndex;
 import org.springframework.data.mongodb.core.index.Indexed;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
 
 @Document(collection = "p_product_views")
+@CompoundIndex(def = "{'options.option_id': 1}") // 중첩 필드에 대한 인덱스 추가
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ProductView {
@@ -58,7 +61,6 @@ public class ProductView {
     public static class Display {
         @Field("start_at")
         private LocalDateTime startAt;
-
         @Field("end_at")
         private LocalDateTime endAt;
 
@@ -104,7 +106,7 @@ public class ProductView {
         }
 
         for (OptionView option : this.options) {
-            if (option.getOptionId().equals(targetOptionId)) {
+            if (option != null && Objects.equals(option.getOptionId(), targetOptionId)) {
                 option.totalQuantity = newTotalQuantity;
                 option.currentDailyStock = newCurrentDailyStock;
                 break;

--- a/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
+++ b/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
@@ -10,4 +10,6 @@ public interface ProductViewRepository extends MongoRepository<ProductView, Stri
     // @Query 어노테이션 제거함!
     // Spring Data MongoDB가 'options' 배열 안의 'optionId' 필드를 자동으로 찾아줌
     Optional<ProductView> findByOptionsOptionId(UUID optionId);
+
+    Optional<ProductView> findByProductId(UUID productId);
 }

--- a/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
+++ b/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
@@ -6,9 +6,6 @@ import java.util.UUID;
 import org.springframework.data.mongodb.repository.MongoRepository;
 
 public interface ProductViewRepository extends MongoRepository<ProductView, String> {
-
-    // @Query 어노테이션 제거함!
-    // Spring Data MongoDB가 'options' 배열 안의 'optionId' 필드를 자동으로 찾아줌
     Optional<ProductView> findByOptionsOptionId(UUID optionId);
 
     Optional<ProductView> findByProductId(UUID productId);

--- a/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
+++ b/src/main/java/com/michelet/catalog/domain/repository/ProductViewRepository.java
@@ -1,0 +1,13 @@
+package com.michelet.catalog.domain.repository;
+
+import com.michelet.catalog.domain.model.ProductView;
+import java.util.Optional;
+import java.util.UUID;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface ProductViewRepository extends MongoRepository<ProductView, String> {
+
+    // @Query 어노테이션 제거함!
+    // Spring Data MongoDB가 'options' 배열 안의 'optionId' 필드를 자동으로 찾아줌
+    Optional<ProductView> findByOptionsOptionId(UUID optionId);
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
@@ -1,0 +1,29 @@
+package com.michelet.catalog.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
+import org.springframework.kafka.listener.DefaultErrorHandler;
+import org.springframework.util.backoff.FixedBackOff;
+
+@Configuration
+public class KafkaConfig {
+
+    /**
+     * 카프카 컨슈머 에러 핸들러 설정
+     */
+    @Bean
+    public DefaultErrorHandler errorHandler(KafkaTemplate<Object, Object> kafkaTemplate) {
+        // 1. 에러가 난 메시지를 DLT(Dead Letter Topic, 예: stock.reserved.DLT)로 보내는 역할
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
+
+        // 2. 기본 재시도 정책: 1초(1000ms) 간격으로 최대 3번 재시도
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
+
+        // 3. 특정 예외(IllegalArgumentException)는 재시도해봤자 의미 없으므로 재시도 없이 즉시 DLT로 직행하도록 설정
+        errorHandler.addNotRetryableExceptions(IllegalArgumentException.class);
+
+        return errorHandler;
+    }
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -16,11 +16,8 @@ public class StockEventConsumer {
 
     @KafkaListener(topics = "stock.reserved", groupId = "catalog-service-consumer")
     public void consumeStockReservedEvent(StockReservedEvent event) {
-        try {
-            productViewCommandService.applyStockReservedEvent(event);
-        } catch (Exception e) {
-            log.error("stock.reserved 이벤트 처리 중 오류 발생: {}", event, e);
-            // TODO: DLT(Dead Letter Topic)로 전송하거나 재시도 로직 추가 (추후 구현?)
-        }
+        log.info("stock.reserved 이벤트 수신: {}", event);
+        // KafkaListener Container가 에러를 인지하고 재시도 할 수 있도록
+        productViewCommandService.applyStockReservedEvent(event);
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -1,0 +1,26 @@
+package com.michelet.catalog.infrastructure.messaging;
+
+import com.michelet.catalog.application.ProductViewCommandService;
+import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class StockEventConsumer {
+
+    private final ProductViewCommandService productViewCommandService;
+
+    @KafkaListener(topics = "stock.reserved", groupId = "catalog-service-consumer")
+    public void consumeStockReservedEvent(StockReservedEvent event) {
+        try {
+            productViewCommandService.applyStockReservedEvent(event);
+        } catch (Exception e) {
+            log.error("stock.reserved 이벤트 처리 중 오류 발생: {}", event, e);
+            // TODO: DLT(Dead Letter Topic)로 전송하거나 재시도 로직 추가 (추후 구현?)
+        }
+    }
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
@@ -8,4 +8,16 @@ public record StockReservedEvent(
     Integer totalQuantity,
     Integer currentDailyStock
 ) {
+    // Record 생성 시점에 데이터 검증
+    public StockReservedEvent {
+        if (optionId == null) {
+            throw new IllegalArgumentException("optionId must not be null");
+        }
+        if (totalQuantity == null || totalQuantity < 0) {
+            throw new IllegalArgumentException("totalQuantity must not be null or negative");
+        }
+        if (currentDailyStock == null || currentDailyStock < 0) {
+            throw new IllegalArgumentException("currentDailyStock must not be null or negative");
+        }
+    }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
@@ -1,5 +1,6 @@
 package com.michelet.catalog.infrastructure.messaging.dto;
 
+import java.util.Objects;
 import java.util.UUID;
 
 // 인벤토리 서비스에서 전송하는 JSON 구조와 매핑됨
@@ -10,14 +11,14 @@ public record StockReservedEvent(
 ) {
     // Record 생성 시점에 데이터 검증
     public StockReservedEvent {
-        if (optionId == null) {
-            throw new IllegalArgumentException("optionId must not be null");
-        }
-        if (totalQuantity == null || totalQuantity < 0) {
-            throw new IllegalArgumentException("totalQuantity must not be null or negative");
-        }
-        if (currentDailyStock == null || currentDailyStock < 0) {
-            throw new IllegalArgumentException("currentDailyStock must not be null or negative");
+        // 1. 필수 값(Null) 검증
+        Objects.requireNonNull(optionId, "옵션 ID(optionId)는 필수입니다.");
+        Objects.requireNonNull(totalQuantity, "총 재고 수량(totalQuantity)은 필수입니다.");
+        Objects.requireNonNull(currentDailyStock, "일일 재고 수량(currentDailyStock)은 필수입니다.");
+
+        // 2. 비즈니스 값(음수) 검증
+        if (totalQuantity < 0 || currentDailyStock < 0) {
+            throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
         }
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/StockReservedEvent.java
@@ -1,0 +1,11 @@
+package com.michelet.catalog.infrastructure.messaging.dto;
+
+import java.util.UUID;
+
+// 인벤토리 서비스에서 전송하는 JSON 구조와 매핑됨
+public record StockReservedEvent(
+    UUID optionId,
+    Integer totalQuantity,
+    Integer currentDailyStock
+) {
+}

--- a/src/main/java/com/michelet/catalog/presentation/ProductViewController.java
+++ b/src/main/java/com/michelet/catalog/presentation/ProductViewController.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -19,8 +20,15 @@ public class ProductViewController {
 
     private final ProductViewQueryService productViewQueryService;
 
+    private static final int MAX_PAGE_SIZE = 50;
+
     @GetMapping
-    public ResponseEntity<Page<ProductViewResponse>> getProducts(Pageable pageable) {
+    public ResponseEntity<Page<ProductViewResponse>> getProducts(
+        @PageableDefault(size = 10) Pageable pageable) {
+        if (pageable.getPageSize() > MAX_PAGE_SIZE) {
+            throw new IllegalArgumentException("한 번에 최대 " + MAX_PAGE_SIZE + "개까지만 조회할 수 있습니다.");
+        }
+
         return ResponseEntity.ok(productViewQueryService.getProducts(pageable));
     }
 

--- a/src/main/java/com/michelet/catalog/presentation/ProductViewController.java
+++ b/src/main/java/com/michelet/catalog/presentation/ProductViewController.java
@@ -1,0 +1,31 @@
+package com.michelet.catalog.presentation;
+
+import com.michelet.catalog.application.ProductViewQueryService;
+import com.michelet.catalog.presentation.dto.ProductViewResponse;
+import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/products")
+@RequiredArgsConstructor
+public class ProductViewController {
+
+    private final ProductViewQueryService productViewQueryService;
+
+    @GetMapping
+    public ResponseEntity<Page<ProductViewResponse>> getProducts(Pageable pageable) {
+        return ResponseEntity.ok(productViewQueryService.getProducts(pageable));
+    }
+
+    @GetMapping("/{productId}")
+    public ResponseEntity<ProductViewResponse> getProduct(@PathVariable UUID productId) {
+        return ResponseEntity.ok(productViewQueryService.getProduct(productId));
+    }
+}

--- a/src/main/java/com/michelet/catalog/presentation/dto/ProductViewResponse.java
+++ b/src/main/java/com/michelet/catalog/presentation/dto/ProductViewResponse.java
@@ -1,0 +1,52 @@
+package com.michelet.catalog.presentation.dto;
+
+import com.michelet.catalog.domain.model.ProductView;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record ProductViewResponse(
+    UUID productId,
+    UUID restaurantId,
+    String name,
+    String category,
+    Map<String, Object> metadata,
+    boolean isVisible,
+    List<OptionResponse> options
+) {
+    public static ProductViewResponse from(ProductView productView) {
+        List<OptionResponse> optionResponses = productView.getOptions() != null ?
+            productView.getOptions().stream()
+                .map(OptionResponse::from)
+                .toList() : List.of();
+
+        return new ProductViewResponse(
+            productView.getProductId(),
+            productView.getRestaurantId(),
+            productView.getName(),
+            productView.getCategory(),
+            productView.getMetadata(),
+            productView.isVisible(),
+            optionResponses
+        );
+    }
+
+    public record OptionResponse(
+        UUID optionId,
+        String name,
+        BigDecimal addPrice,
+        Integer totalQuantity,
+        Integer currentDailyStock
+    ) {
+        public static OptionResponse from(ProductView.OptionView optionView) {
+            return new OptionResponse(
+                optionView.getOptionId(),
+                optionView.getName(),
+                optionView.getAddPrice(),
+                optionView.getTotalQuantity(),
+                optionView.getCurrentDailyStock()
+            );
+        }
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,6 +2,7 @@ spring:
     data:
         mongodb:
             uri: mongodb://mongo-db:27017/michelet_catalog
+            uuid-representation: standard  # MongoDB 표준 UUID 사용
     kafka:
         bootstrap-servers: kafka:9092
         consumer:
@@ -10,7 +11,9 @@ spring:
             key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
             value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
             properties:
-                spring.json.trusted.packages: "com.michelet.catalog"
+                spring.json.trusted.packages: "com.michelet.*"
+                spring.json.use.type.headers: false
+                spring.json.value.default.type: com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent # 기본 객체 매핑
 
 eureka:
     client:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,7 @@ spring:
     data:
         mongodb:
             uri: mongodb://localhost:27017/michelet_catalog
+            uuid-representation: standard
     kafka:
         bootstrap-servers: localhost:9092
         consumer:
@@ -10,7 +11,9 @@ spring:
             key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
             value-deserializer: org.springframework.kafka.support.serializer.JsonDeserializer
             properties:
-                spring.json.trusted.packages: "com.michelet.catalog"
+                spring.json.trusted.packages: "com.michelet.*"
+                spring.json.use.type.headers: false
+                spring.json.value.default.type: com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent
 
 eureka:
     client:

--- a/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
+++ b/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
@@ -90,6 +90,6 @@ class ProductViewQueryServiceTest {
         // when & then
         assertThatThrownBy(() -> productViewQueryService.getProduct(productId))
             .isInstanceOf(ProductNotFoundException.class)
-            .hasMessageContaining("상품을 찾을 수 없습니다");
+            .hasMessageContaining("해당 상품을 찾을 수 없습니다");
     }
 }

--- a/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
+++ b/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
@@ -1,13 +1,16 @@
 package com.michelet.catalog.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
 
+import com.michelet.catalog.domain.exception.ProductNotFoundException;
 import com.michelet.catalog.domain.model.ProductView;
 import com.michelet.catalog.domain.repository.ProductViewRepository;
 import com.michelet.catalog.presentation.dto.ProductViewResponse;
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -50,7 +53,43 @@ class ProductViewQueryServiceTest {
         // then
         assertThat(result.getContent()).hasSize(1);
         assertThat(result.getContent().get(0).productId()).isEqualTo(productId);
-        assertThat(result.getContent().get(0).name()).isEqualTo("밀키트 A");
-        assertThat(result.getContent().get(0).options().get(0).currentDailyStock()).isEqualTo(20);
+//        assertThat(result.getContent().get(0).name()).isEqualTo("밀키트 A");
+//        assertThat(result.getContent().get(0).options().get(0).currentDailyStock()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("성공: 특정 ID의 상품을 단건 조회할 수 있다.")
+    void getProduct_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20);
+        ProductView productView = ProductView.builder()
+            .productId(productId)
+            .name("단건 상품")
+            .isVisible(true)
+            .options(List.of(option))
+            .build();
+
+        given(productViewRepository.findByProductId(productId)).willReturn(Optional.of(productView));
+
+        // when
+        ProductViewResponse result = productViewQueryService.getProduct(productId);
+
+        // then
+        assertThat(result.productId()).isEqualTo(productId);
+        assertThat(result.name()).isEqualTo("단건 상품");
+    }
+
+    @Test
+    @DisplayName("실패: 존재하지 않는 상품 ID로 조회하면 ProductNotFoundException이 발생한다.")
+    void getProduct_NotFound_ThrowsException() {
+        // given
+        UUID productId = UUID.randomUUID();
+        given(productViewRepository.findByProductId(productId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> productViewQueryService.getProduct(productId))
+            .isInstanceOf(ProductNotFoundException.class)
+            .hasMessageContaining("상품을 찾을 수 없습니다");
     }
 }

--- a/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
+++ b/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
@@ -1,0 +1,56 @@
+package com.michelet.catalog.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.michelet.catalog.domain.model.ProductView;
+import com.michelet.catalog.domain.repository.ProductViewRepository;
+import com.michelet.catalog.presentation.dto.ProductViewResponse;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+@ExtendWith(MockitoExtension.class)
+class ProductViewQueryServiceTest {
+
+    @InjectMocks
+    private ProductViewQueryService productViewQueryService;
+
+    @Mock
+    private ProductViewRepository productViewRepository;
+
+    @Test
+    @DisplayName("성공: 카탈로그 상품 목록을 페이징하여 조회할 수 있다.")
+    void getProducts_Success() {
+        // given
+        UUID productId = UUID.randomUUID();
+        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20);
+        ProductView productView = ProductView.builder()
+            .productId(productId)
+            .name("밀키트 A")
+            .isVisible(true)
+            .options(List.of(option))
+            .build();
+
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        given(productViewRepository.findAll(pageRequest)).willReturn(new PageImpl<>(List.of(productView)));
+
+        // when
+        Page<ProductViewResponse> result = productViewQueryService.getProducts(pageRequest);
+
+        // then
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).productId()).isEqualTo(productId);
+        assertThat(result.getContent().get(0).name()).isEqualTo("밀키트 A");
+        assertThat(result.getContent().get(0).options().get(0).currentDailyStock()).isEqualTo(20);
+    }
+}

--- a/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
+++ b/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
@@ -57,4 +57,25 @@ class ProductViewControllerTest {
 
         then(productViewQueryService).should().getProducts(eq(pageRequest));
     }
+
+    @Test
+    @DisplayName("성공: size=50(최대 허용값) 요청을 정상 처리한다.")
+    void getProducts_MaxPageSizeAccepted() throws Exception {
+        // given
+        ProductViewResponse response = new ProductViewResponse(
+            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", null, true, List.of()
+        );
+        PageRequest pageRequest = PageRequest.of(0, 50);
+        given(productViewQueryService.getProducts(eq(pageRequest)))
+            .willReturn(new PageImpl<>(List.of(response), pageRequest, 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products")
+                .param("page", "0")
+                .param("size", "50"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.page.size").value(50));
+
+        then(productViewQueryService).should().getProducts(eq(pageRequest));
+    }
 }

--- a/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
+++ b/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
@@ -1,0 +1,57 @@
+package com.michelet.catalog.presentation;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.michelet.catalog.application.ProductViewQueryService;
+import com.michelet.catalog.presentation.dto.ProductViewResponse;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(ProductViewController.class)
+class ProductViewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ProductViewQueryService productViewQueryService;
+
+    @Test
+    @DisplayName("성공: 카탈로그 목록 조회 시 VIA_DTO 페이지 직렬화 규약을 준수하여 응답한다.")
+    void getProducts_PageSerialization_ViaDto() throws Exception {
+        // given
+        ProductViewResponse response = new ProductViewResponse(
+            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", null, true, List.of()
+        );
+        PageRequest pageRequest = PageRequest.of(0, 20);
+        // 1개의 요소를 가진 페이지 Mock 응답 생성
+        given(productViewQueryService.getProducts(any()))
+            .willReturn(new PageImpl<>(List.of(response), pageRequest, 1));
+
+        // when & then
+        mockMvc.perform(get("/api/v1/products")
+                .param("page", "0")
+                .param("size", "20"))
+            .andExpect(status().isOk())
+            // 1. VIA_DTO 규약: 실제 데이터는 'content' 배열 내부에 존재
+            .andExpect(jsonPath("$.content").isArray())
+            .andExpect(jsonPath("$.content[0].name").value("테스트 상품"))
+            // 2. VIA_DTO 규약: 페이징 메타데이터는 'page' 객체 내부에 응집
+            .andExpect(jsonPath("$.page.size").value(20))
+            .andExpect(jsonPath("$.page.number").value(0))
+            .andExpect(jsonPath("$.page.totalElements").value(1))
+            .andExpect(jsonPath("$.page.totalPages").value(1));
+    }
+}

--- a/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
+++ b/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
@@ -1,7 +1,8 @@
 package com.michelet.catalog.presentation;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -37,7 +38,7 @@ class ProductViewControllerTest {
         );
         PageRequest pageRequest = PageRequest.of(0, 20);
         // 1개의 요소를 가진 페이지 Mock 응답 생성
-        given(productViewQueryService.getProducts(any()))
+        given(productViewQueryService.getProducts(eq(pageRequest)))
             .willReturn(new PageImpl<>(List.of(response), pageRequest, 1));
 
         // when & then
@@ -53,5 +54,7 @@ class ProductViewControllerTest {
             .andExpect(jsonPath("$.page.number").value(0))
             .andExpect(jsonPath("$.page.totalElements").value(1))
             .andExpect(jsonPath("$.page.totalPages").value(1));
+
+        then(productViewQueryService).should().getProducts(eq(pageRequest));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- **Read Model 갱신 로직 구현**: 인벤토리 서비스에서 재고가 차감되었을 때 발행되는 `stock.reserved` 카프카 이벤트를 수신하여, 카탈로그의 MongoDB 데이터를 동기화하는 로직을 구현
- **Kafka 역직렬화 결합도 제거**: 이벤트 발행 측의 패키지 경로에 의존하지 않도록, `application.yml`에 `spring.json.use.type.headers: false` 설정을 추가하고 카탈로그 내부의 DTO로 강제 매핑되도록 처리
- **MongoDB UUID 표준화**: MongoDB 조회 시 Legacy UUID와 Standard UUID 불일치로 인한 쿼리 실패를 방지하기 위해 `uuid-representation: standard` 설정을 추가

-  **Read Model 조회 API 구현**: MongoDB에 동기화된 상품 정보를 조회하는 `GET /api/v1/products` 및 단건 조회 API를 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #3   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] Postman 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 Postman 실행 화면을 여기에 첨부해 주세요.
<img width="528" height="520" alt="스크린샷 2026-04-29 오후 5 48 18" src="https://github.com/user-attachments/assets/ea3bcbeb-9283-4f3b-9600-1fb64bb39a4a" />
<img width="526" height="726" alt="스크린샷 2026-04-29 오후 5 48 25" src="https://github.com/user-attachments/assets/56a91ca1-3717-4d13-a2ec-5fc104ad3cf6" />
<img width="527" height="741" alt="스크린샷 2026-04-29 오후 5 48 30" src="https://github.com/user-attachments/assets/1f9e4b81-555e-44d5-b96c-e743ee42101b" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.
> - [ ] 논의점
<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 상품 목록(페이지네이션) 및 상세 조회 API 추가(페이지 사이즈 상한 검증 포함).
  * 상품 조회·커맨드 서비스와 상품 뷰 모델/저장소 추가 및 옵션별 가격·재고 응답 포맷 제공.
  * 재고 예약 이벤트 수신(Kafka) 시 옵션별 재고 즉시 반영 처리 및 오류 재시도/데드레터 처리 구성 추가.

* **예외/오류**
  * 상품 미발견 전용 비즈니스 예외 및 오류 코드 추가.

* **테스트**
  * 컨트롤러 및 쿼리 서비스 단위 테스트 추가.

* **Chores**
  * 메시지 역직렬화 및 MongoDB UUID 설정 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->