### PR TITLE
Feat/12 - 인벤토리 스케줄러 연동 및 전시/재고 상태 실시간 동기화 구현

### DIFF
--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -18,6 +18,7 @@ Authorization: Bearer {{auth_token}}
 ### 2. [Public] 상품 상세 조회 (단건)
 # inventory.http에서 상품 등록 후 넘어온 shared_product_id 사용
 GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{shared_product_id}}
+#GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{expired_product_id}}
 Accept: application/json
 Authorization: Bearer {{auth_token}}
 
@@ -51,13 +52,14 @@ Authorization: Bearer {{auth_token}}
 > {%
     client.test("카탈로그 스케줄러 동기화: 전시 상태 HIDDEN 변경 확인", function () {
         client.assert(response.status === 200, "조회 실패");
-        if (response.body && response.body.data) {
-            var status = response.body.data.status;
-            client.assert(status === "HIDDEN", "상태가 HIDDEN으로 동기화되지 않았습니다. 현재 상태: " + status);
-            client.log("전시 상태 HIDDEN 변경 동기화 완료");
-        } else {
-            client.log("[에러] 데이터가 없습니다.");
-        }
+
+        // assert를 사용하여 값이 없는 경우 즉시 실패 처리
+        client.assert(response.body && response.body.data, "응답 데이터가 없습니다.");
+
+        var status = response.body.data.status;
+        client.assert(status === "HIDDEN", "상태가 HIDDEN으로 동기화되지 않았습니다. 현재 상태: " + status);
+
+        client.log("전시 상태 HIDDEN 변경 동기화 완료");
     });
 %}
 
@@ -69,14 +71,15 @@ Authorization: Bearer {{auth_token}}
 > {%
     client.test("카탈로그 스케줄러 동기화: 일일 재고 리셋 확인", function () {
         client.assert(response.status === 200, "조회 실패");
-        if (response.body && response.body.data) {
-            var option = response.body.data.options[0];
-            // 이전에 inventory.http 3번(Reserve)에서 3개를 깎았으므로,
-            // 스케줄러가 돌았다면 17개(20-3)보다 많은 초기값(20 또는 100)으로 리셋되어야 함
-            client.assert(option.currentDailyStock > 17, "재고가 리셋되지 않았습니다! 현재: " + option.currentDailyStock);
-            client.log("재고 리셋 동기화 완료: 현재 일일 재고 " + option.currentDailyStock);
-        } else {
-            client.log("[에러] 데이터가 없습니다.");
-        }
+
+        // assert를 사용하여 값이 없는 경우 즉시 실패 처리
+        client.assert(response.body && response.body.data, "응답 데이터가 없습니다.");
+        client.assert(response.body.data.options && response.body.data.options.length > 0, "옵션 데이터가 누락되었습니다.");
+
+        var option = response.body.data.options[0];
+
+        // 느슨한 > 17 검증 대신 정확한 === 20 동치 검증 사용
+        client.assert(option.currentDailyStock === 20, "재고가 20이어야 하는데 현재 " + option.currentDailyStock);
+        client.log("재고 리셋 동기화 완료: 현재 일일 재고 " + option.currentDailyStock);
     });
 %}

--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -42,3 +42,41 @@ X-User-Role: SYSTEM
         client.log("최종 계산된 결제 가격: " + response.body.data.totalPrice);
     });
 %}
+
+### 4. [Public] 기간 만료 상품 단건 조회 (전시 상태 스케줄러 동기화 검증) - (주의: inventory.http에서 스케줄러 트리거 호출 후에 실행하기)
+GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{expired_product_id}}
+Accept: application/json
+Authorization: Bearer {{auth_token}}
+
+> {%
+    client.test("카탈로그 스케줄러 동기화: 전시 상태 HIDDEN 변경 확인", function () {
+        client.assert(response.status === 200, "조회 실패");
+        if (response.body && response.body.data) {
+            var status = response.body.data.status;
+            client.assert(status === "HIDDEN", "상태가 HIDDEN으로 동기화되지 않았습니다. 현재 상태: " + status);
+            client.log("전시 상태 HIDDEN 변경 동기화 완료");
+        } else {
+            client.log("[에러] 데이터가 없습니다.");
+        }
+    });
+%}
+
+### 5. [Public] 정상 상품 단건 조회 (일일 재고 리셋 스케줄러 동기화 검증)
+GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{shared_product_id}}
+Accept: application/json
+Authorization: Bearer {{auth_token}}
+
+> {%
+    client.test("카탈로그 스케줄러 동기화: 일일 재고 리셋 확인", function () {
+        client.assert(response.status === 200, "조회 실패");
+        if (response.body && response.body.data) {
+            var option = response.body.data.options[0];
+            // 이전에 inventory.http 3번(Reserve)에서 3개를 깎았으므로,
+            // 스케줄러가 돌았다면 17개(20-3)보다 많은 초기값(20 또는 100)으로 리셋되어야 함
+            client.assert(option.currentDailyStock > 17, "재고가 리셋되지 않았습니다! 현재: " + option.currentDailyStock);
+            client.log("재고 리셋 동기화 완료: 현재 일일 재고 " + option.currentDailyStock);
+        } else {
+            client.log("[에러] 데이터가 없습니다.");
+        }
+    });
+%}

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -4,7 +4,9 @@ import com.michelet.catalog.domain.exception.ProductNotFoundException;
 import com.michelet.catalog.domain.model.ProductView;
 import com.michelet.catalog.domain.model.ProductView.OptionView;
 import com.michelet.catalog.domain.repository.ProductViewRepository;
+import com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent;
+import com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent;
 import java.util.List;
@@ -41,7 +43,8 @@ public class ProductViewCommandService {
                 opt.name(),
                 opt.addPrice(),
                 opt.totalQuantity(),
-                opt.currentDailyStock()
+                opt.currentDailyStock(),
+                opt.dailyLimit()
             ))
             .toList();
 
@@ -52,9 +55,10 @@ public class ProductViewCommandService {
             .restaurantId(event.restaurantId())
             .name(event.name())
             .category(event.category())
+            .status("ACTIVE") // 초기 상태 세팅
             .basePrice(event.basePrice())
             .metadata(event.attributes())
-            .isVisible(true) // FIXME: 테스트 완료 후 다시 false로 원복 및 스케줄러 연동 - 나중에 시간에 맞춰 오픈되도록 해야함
+            .isVisible(true) // FIXME: 테스트 완료 후 다시 false로 원복 및 스케줄러 연동
             .display(display)
             .options(optionViews)
             .build();
@@ -108,5 +112,37 @@ public class ProductViewCommandService {
         // 3. MongoDB에 저장 (덮어쓰기)
         productViewRepository.save(productView);
         log.info("MongoDB 재고 복구 업데이트 완료: productId={}", productView.getProductId());
+    }
+
+    /**
+     * 상품 전시 상태 업데이트 이벤트를 처리함
+     */
+    public void updateProductStatus(ProductStatusChangedEvent event) {
+        if (event == null) {
+            throw new IllegalArgumentException("이벤트 페이로드가 null입니다.");
+        }
+
+        productViewRepository.findByProductId(event.productId())
+            .ifPresent(view -> {
+                view.updateStatus(event.newStatus());
+                productViewRepository.save(view);
+                log.info("MongoDB 상품 상태 동기화 완료: productId={}, status={}", event.productId(), event.newStatus());
+            });
+    }
+
+    /**
+     * 전체 상품 일일 재고 리셋 이벤트를 처리함
+     */
+    public void resetAllDailyStocks(DailyStockResetEvent event) {
+        if (event == null) {
+            throw new IllegalArgumentException("이벤트 페이로드가 null입니다.");
+        }
+
+        List<ProductView> allProducts = productViewRepository.findAll();
+        for (ProductView product : allProducts) {
+            product.resetDailyStock();
+        }
+        productViewRepository.saveAll(allProducts);
+        log.info("MongoDB 카탈로그 전체 일일 재고 리셋 완료: {}건", allProducts.size());
     }
 }

--- a/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewCommandService.java
@@ -9,9 +9,12 @@ import com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 
 @Slf4j
@@ -50,15 +53,25 @@ public class ProductViewCommandService {
 
         ProductView.Display display = new ProductView.Display(event.startAt(), event.endAt());
 
+        LocalDateTime now = LocalDateTime.now();
+        boolean initialVisibility = false;
+        String initialStatus = "HIDDEN";
+
+        if (event.startAt() != null && !now.isBefore(event.startAt()) &&
+            (event.endAt() == null || now.isBefore(event.endAt()))) {
+            initialVisibility = true;
+            initialStatus = "ACTIVE";
+        }
+
         ProductView productView = ProductView.builder()
             .productId(event.productId())
             .restaurantId(event.restaurantId())
             .name(event.name())
             .category(event.category())
-            .status("ACTIVE") // 초기 상태 세팅
+            .status(initialStatus) //동적 상태 세팅
             .basePrice(event.basePrice())
             .metadata(event.attributes())
-            .isVisible(true) // FIXME: 테스트 완료 후 다시 false로 원복 및 스케줄러 연동
+            .isVisible(initialVisibility)
             .display(display)
             .options(optionViews)
             .build();
@@ -122,12 +135,16 @@ public class ProductViewCommandService {
             throw new IllegalArgumentException("이벤트 페이로드가 null입니다.");
         }
 
-        productViewRepository.findByProductId(event.productId())
-            .ifPresent(view -> {
-                view.updateStatus(event.newStatus());
-                productViewRepository.save(view);
-                log.info("MongoDB 상품 상태 동기화 완료: productId={}, status={}", event.productId(), event.newStatus());
+        // 상품이 없을 경우 예외를 던져 DLT로 이동하여 재처리 가능하도록 유도
+        ProductView view = productViewRepository.findByProductId(event.productId())
+            .orElseThrow(() -> {
+                log.warn("상품 상태 동기화 실패 (해당 상품을 찾을 수 없음): productId={}", event.productId());
+                return new ProductNotFoundException();
             });
+
+        view.updateStatus(event.newStatus());
+        productViewRepository.save(view);
+        log.info("MongoDB 상품 상태 동기화 완료: productId={}, status={}", event.productId(), event.newStatus());
     }
 
     /**
@@ -138,11 +155,28 @@ public class ProductViewCommandService {
             throw new IllegalArgumentException("이벤트 페이로드가 null입니다.");
         }
 
-        List<ProductView> allProducts = productViewRepository.findAll();
-        for (ProductView product : allProducts) {
-            product.resetDailyStock();
-        }
-        productViewRepository.saveAll(allProducts);
-        log.info("MongoDB 카탈로그 전체 일일 재고 리셋 완료: {}건", allProducts.size());
+        // findAll()로 인한 OOM 방지를 위해 Batch Processing(Chunk) 도입
+        int pageSize = 100;
+        PageRequest pageRequest = PageRequest.of(0, pageSize);
+        Page<ProductView> page;
+        int totalProcessed = 0;
+
+        do {
+            page = productViewRepository.findAll(pageRequest);
+            if (page.isEmpty()) {
+                break;
+            }
+
+            List<ProductView> batch = page.getContent();
+            for (ProductView product : batch) {
+                product.resetDailyStock();
+            }
+            productViewRepository.saveAll(batch);
+            totalProcessed += batch.size();
+
+            pageRequest = pageRequest.next();
+        } while (page.hasNext());
+
+        log.info("MongoDB 카탈로그 전체 일일 재고 리셋 완료: {}건", totalProcessed);
     }
 }

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -111,11 +111,26 @@ public class ProductView {
 
         // 재고 리셋을 위한 setter 대용 메서드
         public void resetDailyStock() {
-            this.currentDailyStock = this.dailyLimit != null ? this.dailyLimit : this.totalQuantity;
+            // dailyLimit이 totalQuantity를 초과하지 못하도록 Math.min 적용
+            if (this.dailyLimit != null) {
+                this.currentDailyStock = Math.min(this.dailyLimit, this.totalQuantity != null ? this.totalQuantity : 0);
+            } else {
+                this.currentDailyStock = this.totalQuantity;
+            }
         }
 
         // 재고 업데이트를 위한 메서드
         public void updateStock(Integer total, Integer current) {
+            if (total == null || current == null) {
+                throw new IllegalArgumentException("재고 수량은 null일 수 없습니다.");
+            }
+            if (total < 0 || current < 0) {
+                throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
+            }
+            if (current > total) {
+                throw new IllegalArgumentException("일일 재고가 총 재고를 초과할 수 없습니다.");
+            }
+
             this.totalQuantity = total;
             this.currentDailyStock = current;
         }
@@ -139,6 +154,11 @@ public class ProductView {
 
     // 전시 상태 변경
     public void updateStatus(String status) {
+        if (status == null || (!"ACTIVE".equals(status) && !"HIDDEN".equals(status) && !"DELETED".equals(status)
+            && !"SOLDOUT".equals(status))) {
+            throw new IllegalArgumentException("유효하지 않은 상태 값입니다: " + status);
+        }
+
         this.status = status;
         // 상태가 ACTIVE가 아니면 노출 여부(isVisible)도 자동으로 관리
         this.isVisible = "ACTIVE".equals(status);

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -35,6 +35,7 @@ public class ProductView {
 
     private String name;
     private String category;
+    private String status;
 
     @Field("base_price")
     private BigDecimal basePrice;
@@ -48,13 +49,15 @@ public class ProductView {
     private List<OptionView> options;
 
     @Builder
-    private ProductView(UUID productId, UUID restaurantId, String name, String category, BigDecimal basePrice,
+    private ProductView(UUID productId, UUID restaurantId, String name, String category, String status,
+                        BigDecimal basePrice,
                         Map<String, Object> metadata,
                         boolean isVisible, Display display, List<OptionView> options) {
         this.productId = productId;
         this.restaurantId = restaurantId;
         this.name = name;
         this.category = category;
+        this.status = status;
         this.basePrice = basePrice;
         this.metadata = metadata;
         this.isVisible = isVisible;
@@ -93,13 +96,28 @@ public class ProductView {
         @Field("current_daily_stock")
         private Integer currentDailyStock;
 
+        @Field("daily_limit")
+        private Integer dailyLimit;
+
         public OptionView(UUID optionId, String name, BigDecimal addPrice, Integer totalQuantity,
-                          Integer currentDailyStock) {
+                          Integer currentDailyStock, Integer dailyLimit) {
             this.optionId = optionId;
             this.name = name;
             this.addPrice = addPrice;
             this.totalQuantity = totalQuantity;
             this.currentDailyStock = currentDailyStock;
+            this.dailyLimit = dailyLimit;
+        }
+
+        // 재고 리셋을 위한 setter 대용 메서드
+        public void resetDailyStock() {
+            this.currentDailyStock = this.dailyLimit != null ? this.dailyLimit : this.totalQuantity;
+        }
+
+        // 재고 업데이트를 위한 메서드
+        public void updateStock(Integer total, Integer current) {
+            this.totalQuantity = total;
+            this.currentDailyStock = current;
         }
     }
 
@@ -113,9 +131,24 @@ public class ProductView {
 
         for (OptionView option : this.options) {
             if (option != null && Objects.equals(option.getOptionId(), targetOptionId)) {
-                option.totalQuantity = newTotalQuantity;
-                option.currentDailyStock = newCurrentDailyStock;
+                option.updateStock(newTotalQuantity, newCurrentDailyStock);
                 break;
+            }
+        }
+    }
+
+    // 전시 상태 변경
+    public void updateStatus(String status) {
+        this.status = status;
+        // 상태가 ACTIVE가 아니면 노출 여부(isVisible)도 자동으로 관리
+        this.isVisible = "ACTIVE".equals(status);
+    }
+
+    // 일일 재고 리셋
+    public void resetDailyStock() {
+        if (this.options != null) {
+            for (OptionView option : this.options) {
+                option.resetDailyStock();
             }
         }
     }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -1,7 +1,9 @@
 package com.michelet.catalog.infrastructure.messaging;
 
 import com.michelet.catalog.application.ProductViewCommandService;
+import com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent;
+import com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
@@ -23,7 +25,23 @@ public class ProductEventConsumer {
         productViewCommandService.createProductView(event);
     }
 
-    //TODO 향후 추가될 리스너들:
-    // @KafkaListener(topics = "product.status-updated", ...)
-    // @KafkaListener(topics = "product.visible-updated", ...)
+    // 상품 상태 변경 리스너
+    @KafkaListener(
+        topics = "${catalog.kafka.topic.status-changed:product.status-changed}",
+        groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
+    )
+    public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
+        log.info("product.status-changed 이벤트 수신: {}", event);
+        productViewCommandService.updateProductStatus(event);
+    }
+
+    // 일일 재고 초기화 리스너
+    @KafkaListener(
+        topics = "${catalog.kafka.topic.daily-reset:stock.daily-reset}",
+        groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
+    )
+    public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
+        log.info("stock.daily-reset 이벤트 수신: {}", event);
+        productViewCommandService.resetAllDailyStocks(event);
+    }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/DailyStockResetEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/DailyStockResetEvent.java
@@ -1,0 +1,9 @@
+package com.michelet.catalog.infrastructure.messaging.dto;
+
+import java.time.LocalDate;
+
+public record DailyStockResetEvent(
+    LocalDate resetDate,
+    int updatedOptionCount
+) {
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductCreatedEvent.java
@@ -52,6 +52,9 @@ public record ProductCreatedEvent(
             if (totalQuantity < 0 || currentDailyStock < 0 || dailyLimit < 0) {
                 throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
             }
+            if (currentDailyStock > totalQuantity) {
+                throw new IllegalArgumentException("일일 재고 수량이 총 재고 수량을 초과할 수 없습니다.");
+            }
         }
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductCreatedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductCreatedEvent.java
@@ -37,7 +37,8 @@ public record ProductCreatedEvent(
         String name,
         BigDecimal addPrice,
         Integer totalQuantity,
-        Integer currentDailyStock
+        Integer currentDailyStock,
+        Integer dailyLimit
     ) {
         // 컴팩트 생성자 추가 - 옵션 필수 값 및 재고 수량 0 이상 검증
         public OptionEventDto {
@@ -46,8 +47,9 @@ public record ProductCreatedEvent(
             Objects.requireNonNull(addPrice, "addPrice는 필수입니다.");
             Objects.requireNonNull(totalQuantity, "totalQuantity는 필수입니다.");
             Objects.requireNonNull(currentDailyStock, "currentDailyStock는 필수입니다.");
+            Objects.requireNonNull(dailyLimit, "dailyLimit는 필수입니다.");
 
-            if (totalQuantity < 0 || currentDailyStock < 0) {
+            if (totalQuantity < 0 || currentDailyStock < 0 || dailyLimit < 0) {
                 throw new IllegalArgumentException("재고 수량은 0 이상이어야 합니다.");
             }
         }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductStatusChangedEvent.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/dto/ProductStatusChangedEvent.java
@@ -1,0 +1,9 @@
+package com.michelet.catalog.infrastructure.messaging.dto;
+
+import java.util.UUID;
+
+public record ProductStatusChangedEvent(
+    UUID productId,
+    String newStatus
+) {
+}

--- a/src/main/java/com/michelet/catalog/presentation/dto/ProductViewResponse.java
+++ b/src/main/java/com/michelet/catalog/presentation/dto/ProductViewResponse.java
@@ -11,6 +11,7 @@ public record ProductViewResponse(
     UUID restaurantId,
     String name,
     String category,
+    String status,
     Map<String, Object> metadata,
     boolean isVisible,
     List<OptionResponse> options
@@ -26,6 +27,7 @@ public record ProductViewResponse(
             productView.getRestaurantId(),
             productView.getName(),
             productView.getCategory(),
+            productView.getStatus(),
             productView.getMetadata(),
             productView.isVisible(),
             optionResponses
@@ -37,7 +39,8 @@ public record ProductViewResponse(
         String name,
         BigDecimal addPrice,
         Integer totalQuantity,
-        Integer currentDailyStock
+        Integer currentDailyStock,
+        Integer dailyLimit
     ) {
         public static OptionResponse from(ProductView.OptionView optionView) {
             return new OptionResponse(
@@ -45,7 +48,8 @@ public record ProductViewResponse(
                 optionView.getName(),
                 optionView.getAddPrice(),
                 optionView.getTotalQuantity(),
-                optionView.getCurrentDailyStock()
+                optionView.getCurrentDailyStock(),
+                optionView.getDailyLimit()
             );
         }
     }

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,26 +2,8 @@ spring:
     data:
         mongodb:
             uri: mongodb://mongo-db:27017/michelet_catalog
-            uuid-representation: standard  # MongoDB 표준 UUID 사용
     kafka:
         bootstrap-servers: kafka:9092
-        # 에러 시 DLT로 객체를 전송하기 위해 Producer 설정 추가
-        producer:
-            key-serializer: org.apache.kafka.common.serialization.StringSerializer
-            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-        consumer:
-            group-id: catalog-service-consumer
-            auto-offset-reset: earliest
-            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-            # 에러 시 무한 루프 방지를 위한 ErrorHandlingDeserializer 래퍼 적용
-            value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
-            properties:
-                # 실제 역직렬화를 수행할 델리게이트 클래스 지정
-                spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-                spring.json.trusted.packages: "com.michelet.*"
-                spring.json.use.type.headers: true
-                # 서로 다른 패키지의 이벤트를 1:1로 매핑
-                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"
 
 eureka:
     client:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -21,7 +21,7 @@ spring:
                 spring.json.trusted.packages: "com.michelet.*"
                 spring.json.use.type.headers: true
                 # 서로 다른 패키지의 이벤트를 1:1로 매핑
-                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent"
+                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"
 
 eureka:
     client:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,31 +2,10 @@ spring:
     data:
         mongodb:
             uri: mongodb://localhost:27017/michelet_catalog
-            uuid-representation: standard
     kafka:
         bootstrap-servers: localhost:9092
-        # 에러 시 DLT로 객체를 전송하기 위해 Producer 설정 추가
-        producer:
-            key-serializer: org.apache.kafka.common.serialization.StringSerializer
-            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
-        consumer:
-            group-id: catalog-service-consumer
-            auto-offset-reset: earliest
-            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-            # 에러 시 무한 루프 방지를 위한 ErrorHandlingDeserializer 래퍼 적용
-            value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
-            properties:
-                # 실제 역직렬화를 수행할 델리게이트 클래스 지정
-                spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-                spring.json.trusted.packages: "com.michelet.*"
-                spring.json.use.type.headers: true
-                # 서로 다른 패키지의 이벤트를 1:1로 매핑
-                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"
 
 eureka:
     client:
         service-url:
             defaultZone: http://localhost:8761/eureka/
-
-jwt:
-    secret: ${JWT_SECRET}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,7 +21,7 @@ spring:
                 spring.json.trusted.packages: "com.michelet.*"
                 spring.json.use.type.headers: true
                 # 서로 다른 패키지의 이벤트를 1:1로 매핑
-                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent"
+                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"
 
 eureka:
     client:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,7 +26,7 @@ spring:
             properties:
                 # 실제 역직렬화를 수행할 델리게이트 클래스 지정
                 spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
-                spring.json.trusted.packages: "com.michelet.*"
+                spring.json.trusted.packages: "com.michelet.catalog.infrastructure.messaging.dto"
                 spring.json.use.type.headers: true
                 # 서로 다른 패키지의 이벤트를 1:1로 매핑
                 spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,6 +3,33 @@ spring:
         name: catalog-service
     profiles:
         active: local
+    data:
+        mongodb:
+            uuid-representation: standard
+    kafka:
+        # 에러 시 DLT로 객체를 전송하기 위해 Producer 설정 추가
+        producer:
+            key-serializer: org.apache.kafka.common.serialization.StringSerializer
+            value-serializer: org.springframework.kafka.support.serializer.JsonSerializer
+            acks: all
+            retries: 3
+            properties:
+                enable.idempotence: true
+                max.in.flight.requests.per.connection: 5
+                retry.backoff.ms: 1000
+        consumer:
+            group-id: catalog-service-consumer
+            auto-offset-reset: earliest
+            key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+            # 에러 시 무한 루프 방지를 위한 ErrorHandlingDeserializer 래퍼 적용
+            value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+            properties:
+                # 실제 역직렬화를 수행할 델리게이트 클래스 지정
+                spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+                spring.json.trusted.packages: "com.michelet.*"
+                spring.json.use.type.headers: true
+                # 서로 다른 패키지의 이벤트를 1:1로 매핑
+                spring.json.type.mapping: "com.michelet.inventory.application.dto.StockReservedEvent:com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent,com.michelet.inventory.application.dto.ProductCreatedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent,com.michelet.inventory.application.dto.StockRestoredEvent:com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent,com.michelet.inventory.application.dto.ProductStatusChangedEvent:com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent,com.michelet.inventory.application.dto.DailyStockResetEvent:com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent"
 
 server:
     port: 19800
@@ -15,3 +42,9 @@ catalog:
             stock-restored: "stock.restored"
             status-changed: "product.status-changed"
             daily-reset: "stock.daily-reset"
+
+internal:
+    auth:
+        secret: ${INTERNAL_AUTH_SECRET}
+jwt:
+    secret: ${JWT_SECRET}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,3 +13,5 @@ catalog:
             product-created: "product.created"
             stock-reserved: "stock.reserved"
             stock-restored: "stock.restored"
+            status-changed: "product.status-changed"
+            daily-reset: "stock.daily-reset"

--- a/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
+++ b/src/test/java/com/michelet/catalog/application/ProductViewQueryServiceTest.java
@@ -36,7 +36,8 @@ class ProductViewQueryServiceTest {
     void getProducts_Success() {
         // given
         UUID productId = UUID.randomUUID();
-        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20);
+        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20,
+            20);
         ProductView productView = ProductView.builder()
             .productId(productId)
             .name("밀키트 A")
@@ -62,7 +63,8 @@ class ProductViewQueryServiceTest {
     void getProduct_Success() {
         // given
         UUID productId = UUID.randomUUID();
-        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20);
+        ProductView.OptionView option = new ProductView.OptionView(UUID.randomUUID(), "기본", BigDecimal.ZERO, 100, 20,
+            20);
         ProductView productView = ProductView.builder()
             .productId(productId)
             .name("단건 상품")

--- a/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
+++ b/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
@@ -49,6 +49,7 @@ class ProductViewControllerTest {
             // 1. VIA_DTO 규약: 실제 데이터는 'content' 배열 내부에 존재
             .andExpect(jsonPath("$.content").isArray())
             .andExpect(jsonPath("$.content[0].name").value("테스트 상품"))
+            .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
             // 2. VIA_DTO 규약: 페이징 메타데이터는 'page' 객체 내부에 응집
             .andExpect(jsonPath("$.page.size").value(20))
             .andExpect(jsonPath("$.page.number").value(0))
@@ -74,6 +75,7 @@ class ProductViewControllerTest {
                 .param("page", "0")
                 .param("size", "50"))
             .andExpect(status().isOk())
+            .andExpect(jsonPath("$.content[0].status").value("ACTIVE"))
             .andExpect(jsonPath("$.page.size").value(50));
 
         then(productViewQueryService).should().getProducts(eq(pageRequest));

--- a/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
+++ b/src/test/java/com/michelet/catalog/presentation/ProductViewControllerTest.java
@@ -34,7 +34,7 @@ class ProductViewControllerTest {
     void getProducts_PageSerialization_ViaDto() throws Exception {
         // given
         ProductViewResponse response = new ProductViewResponse(
-            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", null, true, List.of()
+            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", "ACTIVE", null, true, List.of()
         );
         PageRequest pageRequest = PageRequest.of(0, 20);
         // 1개의 요소를 가진 페이지 Mock 응답 생성
@@ -63,7 +63,7 @@ class ProductViewControllerTest {
     void getProducts_MaxPageSizeAccepted() throws Exception {
         // given
         ProductViewResponse response = new ProductViewResponse(
-            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", null, true, List.of()
+            UUID.randomUUID(), UUID.randomUUID(), "테스트 상품", "카테고리", "ACTIVE", null, true, List.of()
         );
         PageRequest pageRequest = PageRequest.of(0, 50);
         given(productViewQueryService.getProducts(eq(pageRequest)))

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -27,3 +27,5 @@ catalog:
             product-created: "product.created"
             stock-reserved: "stock.reserved"
             stock-restored: "stock.restored"
+            status-changed: "product.status-changed"
+            daily-reset: "stock.daily-reset"

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,10 +16,10 @@ spring:
         hibernate:
             ddl-auto: create-drop
 
-#    # 만약 MongoDB 관련 에러가 발생한다면 아래 설정을 추가
-#    # data:
-#    #   mongodb:
-#    #     uri: mongodb://localhost:27017/test
+    # 만약 MongoDB 관련 에러가 발생한다면 아래 설정을 추가
+    # data:
+    #   mongodb:
+    #     uri: mongodb://localhost:27017/test
 
 catalog:
     kafka:
@@ -29,3 +29,9 @@ catalog:
             stock-restored: "stock.restored"
             status-changed: "product.status-changed"
             daily-reset: "stock.daily-reset"
+
+internal:
+    auth:
+        secret: ${INTERNAL_AUTH_SECRET:michelet-internal-auth-secret-key-a8K2mQ9xLp4Vt7Rz1Nc}
+jwt:
+    secret: ${JWT_SECRET:michelet-secret-key-for-authentication}


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.

인벤토리 서비스에서 발행하는 스케줄러 이벤트(일일 재고 복구, 전시기간 반영)를 구독하여 MongoDB 상품 조회 스냅샷의 판매 상태와 재고 수량을 실시간으로 동기화하는 기능을 구현

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #12   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="977" height="525" alt="스크린샷 2026-05-04 오전 4 19 18" src="https://github.com/user-attachments/assets/ab311bba-4e59-4dac-ad8c-4e04659d1137" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

* inventory.http에서 깎아둔 재고와 만료된 상품이 인벤토리 스케줄러 실행 후 카탈로그 API에서 각각 20개 리셋 및 HIDDEN 상태로 변경되는 것 검증했습니다

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 제품 상태(ACTIVE/HIDDEN) 영속화 및 노출(isVisible) 동작 개선
  * 일일 재고 일괄 리셋 기능 추가
  * 옵션별 일일 구매 한도(dailyLimit) 지원 및 재고 계산 변경

* **Tests**
  * 제품 상세 응답 검증 강화(숨김 상태, 옵션 존재/재고 값 엄격 검사)
  * 상태 변경·일일 리셋 동기화 테스트 추가

* **Chores**
  * Kafka 토픽 구성 및 애플리케이션 설정 정리/추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->