### PR TITLE
refactor/23 - 일일 재고 리셋 consumer 코드 위치 수정

### DIFF
--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -161,8 +161,9 @@ public class ProductView {
 
     // 전시 상태 변경
     public void updateStatus(String status) {
-        if (status == null || (!"ACTIVE".equals(status) && !"HIDDEN".equals(status) && !"DELETED".equals(status)
-            && !"SOLDOUT".equals(status) && !"EXPIRED".equals(status))) {
+        if (status == null ||
+            (!"ACTIVE".equals(status) && !"HIDDEN".equals(status) && !"DELETED".equals(status) && !"SOLDOUT".equals(
+                status) && !"EXPIRED".equals(status))) {
             throw new IllegalArgumentException("유효하지 않은 상태 값입니다: " + status);
         }
 

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -1,7 +1,6 @@
 package com.michelet.catalog.infrastructure.messaging;
 
 import com.michelet.catalog.application.ProductViewCommandService;
-import com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductCreatedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.ProductUpdatedEvent;
@@ -44,15 +43,5 @@ public class ProductEventConsumer {
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
         log.info("product.status-changed 이벤트 수신: {}", event);
         productViewCommandService.updateProductStatus(event);
-    }
-
-    // 일일 재고 초기화 리스너
-    @KafkaListener(
-        topics = "${catalog.kafka.topic.daily-reset:stock.daily-reset}",
-        groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
-    )
-    public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
-        log.info("stock.daily-reset 이벤트 수신: {}", event);
-        productViewCommandService.resetAllDailyStocks(event);
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -1,6 +1,7 @@
 package com.michelet.catalog.infrastructure.messaging;
 
 import com.michelet.catalog.application.ProductViewCommandService;
+import com.michelet.catalog.infrastructure.messaging.dto.DailyStockResetEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent;
 import lombok.RequiredArgsConstructor;
@@ -34,6 +35,13 @@ public class StockEventConsumer {
         productViewCommandService.applyStockRestoredEvent(event);
     }
 
-    //TODO 향후 추가될 리스너들:
-    // @KafkaListener(topics = "stock.daily-reset", ...)
+    // 일일 재고 초기화 리스너
+    @KafkaListener(
+        topics = "${catalog.kafka.topic.daily-reset:stock.daily-reset}",
+        groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
+    )
+    public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
+        log.info("stock.daily-reset 이벤트 수신: {}", event);
+        productViewCommandService.resetAllDailyStocks(event);
+    }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 일일 재고 리셋 consumer 코드의 단순 위치 이동

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #23   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.

## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

**리팩터링**
* 일일 재고 초기화 이벤트 처리 로직을 내부적으로 재구성했습니다.
* 상품 상태 유효성 검사 로직을 개선하여 코드 구조를 정리했습니다.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/catalog-service/pull/24)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->