### PR TITLE
feat/25 - 카탈로그에서 DLT 수신

### DIFF
--- a/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
@@ -74,9 +74,18 @@ public class KafkaConfig {
 
         props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        props.remove("spring.deserializer.value.delegate.class"); // JSON 파싱 찌꺼기 제거
+
+        // ErrorHandlingDeserializer/Json 관련 잔여 설정 일관성 있게 정리
+        props.remove("spring.deserializer.key.delegate.class");
+        props.remove("spring.deserializer.value.delegate.class");
+        props.remove("spring.json.trusted.packages");
+        props.remove("spring.json.type.mapping");
 
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(props));
+
+        // DLT 처리 실패 시 기본 핸들러(FixedBackOff(0,9))로 폴백되지 않도록 명시적 지정
+        factory.setCommonErrorHandler(new DefaultErrorHandler(new FixedBackOff(0L, 0L)));
+
         return factory;
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
@@ -44,8 +44,12 @@ public class KafkaConfig {
 
         DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer,
             new FixedBackOff(retryIntervalMs, retryMaxAttempts));
-        // 어떤 에러든 재시도 없이 즉시 DLT로 던져서 확인하기 위함
-        errorHandler.addNotRetryableExceptions(Exception.class);
+        // 재시도가 의미 없는 예외만 즉시 DLT로 보냄
+        errorHandler.addNotRetryableExceptions(
+            org.springframework.kafka.support.serializer.DeserializationException.class,
+            IllegalArgumentException.class
+        );
+
         return errorHandler;
     }
 

--- a/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/KafkaConfig.java
@@ -1,44 +1,78 @@
 package com.michelet.catalog.infrastructure.config;
 
+import java.util.HashMap;
+import java.util.Map;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.kafka.ConcurrentKafkaListenerContainerFactoryConfigurer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
 import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.listener.DeadLetterPublishingRecoverer;
 import org.springframework.kafka.listener.DefaultErrorHandler;
 import org.springframework.util.backoff.FixedBackOff;
 
+@Slf4j
 @Configuration
 public class KafkaConfig {
+
+    @Value("${catalog.kafka.consumer.retry.interval-ms:1000}")
+    private long retryIntervalMs;
+
+    @Value("${catalog.kafka.consumer.retry.max-attempts:3}")
+    private long retryMaxAttempts;
 
     /**
      * 카프카 컨슈머 에러 핸들러 설정
      */
     @Bean
     public DefaultErrorHandler errorHandler(KafkaTemplate<Object, Object> kafkaTemplate) {
-        // 1. 에러가 난 메시지를 DLT(Dead Letter Topic, 예: stock.reserved.DLT)로 보내는 역할
-        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(kafkaTemplate);
+        DeadLetterPublishingRecoverer recoverer = new DeadLetterPublishingRecoverer(
+            kafkaTemplate,
+            (cr, e) -> {
+                // 이 로그가 찍혀야 정상적으로 DLT로 넘어가는 것임
+                log.error("[장애 감지] 에러 발생! DLT로 이동. 대상 토픽: {}", cr.topic() + ".DLT");
+                return new TopicPartition(cr.topic() + ".DLT", -1); // -1으로 파티션 증발 버그 원천 차단
+            }
+        );
 
-        // 2. 기본 재시도 정책: 1초(1000ms) 간격으로 최대 3번 재시도
-        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer, new FixedBackOff(1000L, 3L));
-
-        // 3. 특정 예외(IllegalArgumentException)는 재시도해봤자 의미 없으므로 재시도 없이 즉시 DLT로 직행하도록 설정
-        errorHandler.addNotRetryableExceptions(IllegalArgumentException.class);
-
+        DefaultErrorHandler errorHandler = new DefaultErrorHandler(recoverer,
+            new FixedBackOff(retryIntervalMs, retryMaxAttempts));
+        // 어떤 에러든 재시도 없이 즉시 DLT로 던져서 확인하기 위함
+        errorHandler.addNotRetryableExceptions(Exception.class);
         return errorHandler;
     }
 
     @Bean
-    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(
-        ConsumerFactory<String, Object> consumerFactory,
-        DefaultErrorHandler errorHandler //위에서 만든 것 주입
+    public ConcurrentKafkaListenerContainerFactory<Object, Object> kafkaListenerContainerFactory(
+        ConcurrentKafkaListenerContainerFactoryConfigurer configurer,
+        ConsumerFactory<Object, Object> consumerFactory,
+        DefaultErrorHandler errorHandler
     ) {
-        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
-        factory.setConsumerFactory(consumerFactory);
-
+        ConcurrentKafkaListenerContainerFactory<Object, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        configurer.configure(factory, consumerFactory);
         factory.setCommonErrorHandler(errorHandler);
+        return factory;
+    }
 
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, String> dltListenerContainerFactory(
+        ConsumerFactory<Object, Object> consumerFactory
+    ) {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        Map<String, Object> props = new HashMap<>(consumerFactory.getConfigurationProperties());
+
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.remove("spring.deserializer.value.delegate.class"); // JSON 파싱 찌꺼기 제거
+
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(props));
         return factory;
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/DeadLetterConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/DeadLetterConsumer.java
@@ -33,12 +33,17 @@ public class DeadLetterConsumer {
         String originalTopic = extractHeaderAsString(record, KafkaHeaders.DLT_ORIGINAL_TOPIC);
         String exceptionMessage = extractHeaderAsString(record, KafkaHeaders.DLT_EXCEPTION_MESSAGE);
 
-        log.error("================================================================================");
-        log.error("[CRITICAL ALERT] 카탈로그 DLT 에러 메시지 격리 수신 완료!");
-        log.error("원본 토픽 : {}", originalTopic);
-        log.error("에러 원인 : {}", exceptionMessage);
-        log.error("원본 데이터 : {}", record.value() != null ? record.value() : "데이터 없음");
-        log.error("================================================================================");
+        log.error("""
+                ================================================================================
+                [CRITICAL ALERT] 카탈로그 DLT 에러 메시지 격리 수신 완료!
+                원본 토픽 : {}
+                에러 원인 : {}
+                원본 데이터 : {}
+                ================================================================================""",
+            originalTopic,
+            exceptionMessage,
+            record.value() != null ? record.value() : "데이터 없음"
+        );
     }
 
     private String extractHeaderAsString(ConsumerRecord<String, String> record, String headerKey) {

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/DeadLetterConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/DeadLetterConsumer.java
@@ -1,0 +1,51 @@
+package com.michelet.catalog.infrastructure.messaging;
+
+import java.nio.charset.StandardCharsets;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.header.Header;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.KafkaHeaders;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class DeadLetterConsumer {
+
+    /**
+     * Catalog 서비스가 구독 중인 모든 토픽의 DLT를 수신함 - 원본 토픽명 뒤에 ".DLT"가 붙은 토픽들을 배열로 등록
+     */
+    @KafkaListener(
+        topics = {
+            "${catalog.kafka.topic.product-created:product.created}.DLT",
+            "${catalog.kafka.topic.product-updated:product.updated}.DLT",
+            "${catalog.kafka.topic.status-changed:product.status-changed}.DLT",
+            "${catalog.kafka.topic.stock-reserved:stock.reserved}.DLT",
+            "${catalog.kafka.topic.stock-restored:stock.restored}.DLT",
+            "${catalog.kafka.topic.daily-reset:stock.daily-reset}.DLT"
+        },
+        groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}-dlt",
+        containerFactory = "dltListenerContainerFactory"
+    )
+    public void consumeDeadLetter(ConsumerRecord<String, String> record) {
+        String originalTopic = extractHeaderAsString(record, KafkaHeaders.DLT_ORIGINAL_TOPIC);
+        String exceptionMessage = extractHeaderAsString(record, KafkaHeaders.DLT_EXCEPTION_MESSAGE);
+
+        log.error("================================================================================");
+        log.error("[CRITICAL ALERT] 카탈로그 DLT 에러 메시지 격리 수신 완료!");
+        log.error("원본 토픽 : {}", originalTopic);
+        log.error("에러 원인 : {}", exceptionMessage);
+        log.error("원본 데이터 : {}", record.value() != null ? record.value() : "데이터 없음");
+        log.error("================================================================================");
+    }
+
+    private String extractHeaderAsString(ConsumerRecord<String, String> record, String headerKey) {
+        Header header = record.headers().lastHeader(headerKey);
+        if (header != null && header.value() != null) {
+            return new String(header.value(), StandardCharsets.UTF_8);
+        }
+        return "알 수 없음";
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,10 @@ catalog:
             status-changed: "product.status-changed"
             daily-reset: "stock.daily-reset"
             product-updated: "product.updated"
+        consumer:
+            retry:
+                interval-ms: 1000
+                max-attempts: 3
 
 internal:
     auth:


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- DLT 수신 부분 작업

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #25   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="1236" height="788" alt="스크린샷 2026-05-13 오후 5 31 41" src="https://github.com/user-attachments/assets/534e4dab-8cb7-47ba-bb4c-33e08b30e138" />
<img width="1150" height="510" alt="스크린샷 2026-05-13 오후 5 32 50" src="https://github.com/user-attachments/assets/259fb2ba-d969-4d5c-9282-90414c2c1bc3" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.


<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * DLT 수신기 추가 — DLT 메시지 자동 수집 및 원본 토픽·예외·페이로드 포함한 심각도 높은 오류 로그 제공

* **개선 사항**
  * 소비자 재시도 간격 및 최대 시도 횟수 설정 파일로 구성 가능
  * DLT로의 명시적 전송 및 재시도 처리 강화(비재시도 예외 확장)
  * DLT 전용 소비 설정으로 문자열 형태 메시지 처리 안정성 및 불필요 재시도 방지

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/catalog-service/pull/32)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->