### PR TITLE
feat/21 - 카탈로그 조회에 레디스 캐시 도입

### DIFF
--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -4,6 +4,8 @@
 @catalogPort = 19800
 @orderPort = 19700
 
+@dummy_restaurant_id = 22222222-2222-2222-2222-222222222222
+
 ### 1. [Test] 내부 API용 테스트 JWT 토큰 발급
 GET http://{{host}}:{{orderPort}}/test/internal-token?audience=catalog-service
 
@@ -190,82 +192,106 @@ Authorization: Bearer {{cat_owner_token}}
     });
 %}
 
-### 002 [Cache-Aside Miss & Hit 유도] 메인 카탈로그 화면 다건 조회 연쇄 전송
+### 002-1 [Cache-Aside] 1차 캐시 미스 적재 및 2차 캐시 히트 자동 검증
 # 최초 호출 시: 몽고DB 조회 연산 발생 (서버 콘솔에 "[Cache Miss] ..." 로그 출력 확인)
 # 직후 재호출 시: Redis 인메모리 스냅샷 적중하여 속도가 1~2ms로 급감하며 콘솔 로그가 침묵함
-GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=1&size=10
+# 동적 변수 추출 - 0페이지 첫 번째 상품을 타겟으로 잡아, 해당 상품의 ID와 재고를 동적 변수에 저장함
+GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=0&size=10
 Accept: application/json
 Authorization: Bearer {{cat_user_token}}
 
 > {%
-    client.test("메인 화면 노출 및 Cache-Aside 적재 성공 확인", function () {
-        client.assert(response.status === 200, "카탈로그 대량 조회 실패");
+    client.test("1차: 메인 화면 노출 및 동적 변수 세팅", function () {
+        client.assert(response.status === 200, "조회 실패");
 
-        // 데이터 전송 규격 매칭 (content 배열 직접 파싱)
-        var content = response.body.content;
-        client.assert(content !== undefined && content.length > 0, "도큐먼트 데이터셋이 비어있음.");
+        var content = response.body.data ? response.body.data.content : response.body.content;
+        client.assert(content !== undefined && content.length > 0, "데이터셋이 비어있음.");
 
-        var targetProduct = content.find(p => p.name === "타겟 부하테스트 상품");
-        client.assert(targetProduct !== undefined, "부하테스트용 타겟 상품 문서가 유실됨.");
+        // 0페이지의 첫 번째 상품을 동적으로 추출하여 테스트 타겟으로
+        var targetProduct = content[0];
 
-        client.log("몽고DB 초기 적재 수량: " + targetProduct.options[0].currentDailyStock + "개 확인.");
-        client.log("동일 요청을 한 번 더 클릭하여 Redis 캐시에서 1ms 만에 Hit 되는지 검증 후 다음 테스트 진행하기");
+        client.global.set("dyn_restaurant_id", targetProduct.restaurantId);
+        client.global.set("dyn_option_id", targetProduct.options[0].optionId);
+        client.global.set("initial_seed_stock", targetProduct.options[0].currentDailyStock);
+
+        client.log("동적 변수 세팅 완료! Target Option ID: " + client.global.get("dyn_option_id"));
+        client.log("초기 재고 스냅샷 저장 완료: " + client.global.get("initial_seed_stock"));
     });
 %}
 
+### 002-2 [자동화] 즉시 동일 요청 재발송을 통한 Cache Hit 데이터 검증
+GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=0&size=10
+Accept: application/json
+Authorization: Bearer {{cat_user_token}}
 
-### 003 [오더 연동 및 카프카 무효화 트리거] 장바구니에 중복 옵션을 담아 주문 발생
+> {%
+    client.test("2차: Redis Cache Hit 정합성 유지 검증", function () {
+        client.assert(response.status === 200, "조회 실패");
+
+        var content = response.body.data ? response.body.data.content : response.body.content;
+        var dynOptionId = client.global.get("dyn_option_id");
+
+        var targetProduct = content.find(p => p.options.some(o => o.optionId === dynOptionId));
+        client.assert(targetProduct !== undefined, "캐시 응답에서 타겟 데이터를 찾을 수 없음 (데이터 유실)");
+
+        client.log("Cache Hit! 캐시 데이터가 완벽하게 유지되어 반환됨.");
+    });
+%}
+
+### 003 [오더 연동] 장바구니 중복 담기 및 기습 주문 발생 (무효화 트리거)
 POST http://{{host}}:{{gatewayPort}}/api/v1/orders
 Content-Type: application/json
 Authorization: Bearer {{cat_user_token}}
 
 {
-    "reservationId": "c4d17b16-c127-4efe-9599-73470904b936",
-    "restaurantId": "85c4b84f-f7f2-46cc-9dfc-4fc6dc805084",
-    "orderName": "레디스 무효화 검증 연동 주문",
+    "reservationId": "{{$random.uuid}}",
+    "restaurantId": "{{dyn_restaurant_id}}",
+    "orderName": "동적 변수 기반 레디스 무효화 주문",
     "receivingMethod": "PICKUP",
     "expiredAt": "2026-12-31T23:59:59",
     "items": [
         {
-            "optionId": "44444444-4444-4444-4444-444444444444",
+            "optionId": "{{dyn_option_id}}",
             "quantity": 2
         },
         {
-            "optionId": "44444444-4444-4444-4444-444444444444",
+            "optionId": "{{dyn_option_id}}",
             "quantity": 3
         }
     ]
 }
 
 > {%
-    client.test("오더 연동 성공 및 롤백 보상 트랜잭션 정상 예약 완료", function () {
-        client.assert(response.status === 201, "오더 서비스 연동 장애 발생");
-        client.log("묶음 주문 전송 성공! 내부 스케줄러가 카프카로 '수량 5개 합산 차감'을 던짐.");
-        client.log("카탈로그 Consumer 서버창에 '[Kafka] stock.reserved 이벤트 수신 및 캐시 무효화 트리거' 문구가 뜨면 바로 다음 테스트 진행.");
+    client.test("오더 연동 성공 대기", function () {
+        client.assert(response.status === 201, "주문 생성 실패");
+        client.log("동적 타겟 상품에 대해 5개 수량 차감 요청 발송 완료!");
     });
 %}
 
-
-### 004. [최종 변동 조회 및 정합성 매칭] 캐시가 무효화되어 최신 정보로 강제 갱신되었는지 검증
-# 만약 캐시가 정상적으로 날아갔다면(Evicted) 다시 한번 "[Cache Miss] ..." 콘솔 로그가 새롭게 찍히고,
-# 유저에게 최종적으로 반환되는 실시간 일일 재고 수량은 '999,995'개로 동기화되어 내려오게 됨
+### 004 [최종 변동 조회] 캐시 무효화 검증
 GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=0&size=10
 Accept: application/json
 Authorization: Bearer {{cat_user_token}}
 
 > {%
-    client.test("대망의 Redis 데이터 무효화 및 최종 정합성 마스터 매칭 검증", function () {
-        client.assert(response.status === 200, "최종 결과 수신 실패");
+    client.test("데이터 정합성 및 캐시 무효화 상대적 델타 검증", function () {
+        client.assert(response.status === 200, "최종 조회 실패");
 
-        var content = response.body.content;
-        var targetProduct = content.find(p => p.name === "타겟 부하테스트 상품");
-        var latestStock = targetProduct.options[0].currentDailyStock;
+        var content = response.body.data ? response.body.data.content : response.body.content;
+        var dynOptionId = client.global.get("dyn_option_id");
 
-        client.log("현재 Redis 및 몽고DB 스냅샷에 마킹된 실시간 잔여 일일 재고: " + latestStock);
+        // 동적으로 추출했던 옵션을 다시 찾음
+        var targetProduct = content.find(p => p.options.some(o => o.optionId === dynOptionId));
+        client.assert(targetProduct !== undefined, "타겟 데이터 유실");
 
-        // 정합성 매치 가드: 100만 개에서 정확히 5개가 빠진 999995여야 성공함
-        client.assert(latestStock === 999995, "[FAIL] 캐시 무효화 연산 실패. 아직 레디스에 과거 데이터 1,000,000개가 그대로 존재함.");
+        var targetOption = targetProduct.options.find(o => o.optionId === dynOptionId);
+        var latestStock = targetOption.currentDailyStock;
 
-        client.log("[SUCCESS] 성공! Cache-Aside 적중 부하 분산과 Kafka 이벤트 기반 실시간 캐시 폭파 정합성 연동이 100% 무결하게 증명됨");
+        var expectedStock = parseInt(client.global.get("initial_seed_stock")) - 5;
+
+        client.log("최신 재고: " + latestStock + " / 예상 재고: " + expectedStock);
+
+        client.assert(latestStock === expectedStock, "캐시 정합성 실패! 현재: " + latestStock + " / 예상: " + expectedStock);
+        client.log("[성공] 하드코딩 없이 동적 변수로 캐시 무효화 정합성 증명 완료!");
     });
 %}

--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -189,3 +189,83 @@ Authorization: Bearer {{cat_owner_token}}
         client.log("점주용 전체 상품 조회 검증 완료!");
     });
 %}
+
+### 002 [Cache-Aside Miss & Hit 유도] 메인 카탈로그 화면 다건 조회 연쇄 전송
+# 최초 호출 시: 몽고DB 조회 연산 발생 (서버 콘솔에 "[Cache Miss] ..." 로그 출력 확인)
+# 직후 재호출 시: Redis 인메모리 스냅샷 적중하여 속도가 1~2ms로 급감하며 콘솔 로그가 침묵함
+GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=1&size=10
+Accept: application/json
+Authorization: Bearer {{cat_user_token}}
+
+> {%
+    client.test("메인 화면 노출 및 Cache-Aside 적재 성공 확인", function () {
+        client.assert(response.status === 200, "카탈로그 대량 조회 실패");
+
+        // 데이터 전송 규격 매칭 (content 배열 직접 파싱)
+        var content = response.body.content;
+        client.assert(content !== undefined && content.length > 0, "도큐먼트 데이터셋이 비어있음.");
+
+        var targetProduct = content.find(p => p.name === "타겟 부하테스트 상품");
+        client.assert(targetProduct !== undefined, "부하테스트용 타겟 상품 문서가 유실됨.");
+
+        client.log("몽고DB 초기 적재 수량: " + targetProduct.options[0].currentDailyStock + "개 확인.");
+        client.log("동일 요청을 한 번 더 클릭하여 Redis 캐시에서 1ms 만에 Hit 되는지 검증 후 다음 테스트 진행하기");
+    });
+%}
+
+
+### 003 [오더 연동 및 카프카 무효화 트리거] 장바구니에 중복 옵션을 담아 주문 발생
+POST http://{{host}}:{{gatewayPort}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{cat_user_token}}
+
+{
+    "reservationId": "c4d17b16-c127-4efe-9599-73470904b936",
+    "restaurantId": "85c4b84f-f7f2-46cc-9dfc-4fc6dc805084",
+    "orderName": "레디스 무효화 검증 연동 주문",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2026-12-31T23:59:59",
+    "items": [
+        {
+            "optionId": "44444444-4444-4444-4444-444444444444",
+            "quantity": 2
+        },
+        {
+            "optionId": "44444444-4444-4444-4444-444444444444",
+            "quantity": 3
+        }
+    ]
+}
+
+> {%
+    client.test("오더 연동 성공 및 롤백 보상 트랜잭션 정상 예약 완료", function () {
+        client.assert(response.status === 201, "오더 서비스 연동 장애 발생");
+        client.log("묶음 주문 전송 성공! 내부 스케줄러가 카프카로 '수량 5개 합산 차감'을 던짐.");
+        client.log("카탈로그 Consumer 서버창에 '[Kafka] stock.reserved 이벤트 수신 및 캐시 무효화 트리거' 문구가 뜨면 바로 다음 테스트 진행.");
+    });
+%}
+
+
+### 004. [최종 변동 조회 및 정합성 매칭] 캐시가 무효화되어 최신 정보로 강제 갱신되었는지 검증
+# 만약 캐시가 정상적으로 날아갔다면(Evicted) 다시 한번 "[Cache Miss] ..." 콘솔 로그가 새롭게 찍히고,
+# 유저에게 최종적으로 반환되는 실시간 일일 재고 수량은 '999,995'개로 동기화되어 내려오게 됨
+GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=0&size=10
+Accept: application/json
+Authorization: Bearer {{cat_user_token}}
+
+> {%
+    client.test("대망의 Redis 데이터 무효화 및 최종 정합성 마스터 매칭 검증", function () {
+        client.assert(response.status === 200, "최종 결과 수신 실패");
+
+        var content = response.body.content;
+        var targetProduct = content.find(p => p.name === "타겟 부하테스트 상품");
+        var latestStock = targetProduct.options[0].currentDailyStock;
+
+        client.log("현재 Redis 및 몽고DB 스냅샷에 마킹된 실시간 잔여 일일 재고: " + latestStock);
+
+        // 정합성 매치 가드: 100만 개에서 정확히 5개가 빠진 999995여야 성공함
+        client.assert(latestStock === 999995, "[FAIL] 캐시 무효화 연산 실패. 아직 레디스에 과거 데이터 1,000,000개가 그대로 존재함.");
+
+        client.log("[SUCCESS] 성공! Cache-Aside 적중 부하 분산과 Kafka 이벤트 기반 실시간 캐시 폭파 정합성 연동이 100% 무결하게 증명됨");
+    });
+%}

--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -209,6 +209,7 @@ Authorization: Bearer {{cat_user_token}}
 
         // 0페이지의 첫 번째 상품을 동적으로 추출하여 테스트 타겟으로
         var targetProduct = content[0];
+        client.assert(targetProduct.options && targetProduct.options.length > 0, "타겟 상품 옵션이 비어있음.");
 
         client.global.set("dyn_restaurant_id", targetProduct.restaurantId);
         client.global.set("dyn_option_id", targetProduct.options[0].optionId);
@@ -248,7 +249,7 @@ Authorization: Bearer {{cat_user_token}}
     "restaurantId": "{{dyn_restaurant_id}}",
     "orderName": "동적 변수 기반 레디스 무효화 주문",
     "receivingMethod": "PICKUP",
-    "expiredAt": "2026-12-31T23:59:59",
+    "expiredAt": "2099-12-31T23:59:59",
     "items": [
         {
             "optionId": "{{dyn_option_id}}",
@@ -268,7 +269,12 @@ Authorization: Bearer {{cat_user_token}}
     });
 %}
 
-### 004 [최종 변동 조회] 캐시 무효화 검증
+
+### 004 [최종 변동 조회] 캐시 무효화 검증 - Kafka 소비 및 캐시 무효화 전파 대기 (비동기 지연 보정)
+< {%
+    client.log("카프카 비동기 캐시 무효화 전파를 위해 3초 대기...");
+    await sleep(3000);
+%}
 GET http://{{host}}:{{gatewayPort}}/api/v1/products?page=0&size=10
 Accept: application/json
 Authorization: Bearer {{cat_user_token}}
@@ -287,6 +293,7 @@ Authorization: Bearer {{cat_user_token}}
         var targetOption = targetProduct.options.find(o => o.optionId === dynOptionId);
         var latestStock = targetOption.currentDailyStock;
 
+        // 절대값이 아닌 '초기값 - 5'가 정확히 맞는지 검증
         var expectedStock = parseInt(client.global.get("initial_seed_stock")) - 5;
 
         client.log("최신 재고: " + latestStock + " / 예상 재고: " + expectedStock);

--- a/build.gradle
+++ b/build.gradle
@@ -43,6 +43,8 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.kafka:spring-kafka-test'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
     testCompileOnly 'org.projectlombok:lombok'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testAnnotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -6,13 +6,18 @@ import com.michelet.catalog.domain.model.ProductView;
 import com.michelet.catalog.domain.repository.ProductViewRepository;
 import com.michelet.catalog.presentation.dto.OptionValidationResponse;
 import com.michelet.catalog.presentation.dto.ProductViewResponse;
+import com.michelet.catalog.presentation.dto.RestPageImpl;
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ProductViewQueryService {
@@ -20,12 +25,21 @@ public class ProductViewQueryService {
     private final ProductViewRepository productViewRepository;
 
     // 고객용 - 노출 중인 상품만 조회
+    // Cache-Aside 패턴 도입: 페이지 번호 단위로 독립적 캐시 생성 관리
+    @Cacheable(value = "products_cache", key = "#pageable.pageNumber", cacheManager = "catalogCacheManager")
     public Page<ProductViewResponse> getActiveProducts(Pageable pageable) {
-        return productViewRepository.findAllVisibleProducts(pageable)
-            .map(ProductViewResponse::from);
+        log.info("[Cache Miss] 몽고DB로 직행하여 노출 상품 목록 조회 활성화 - Page: {}", pageable.getPageNumber());
+
+        Page<ProductView> page = productViewRepository.findAllVisibleProducts(pageable);
+        List<ProductViewResponse> content = page.getContent().stream()
+            .map(ProductViewResponse::from)
+            .toList();
+
+        // 500 역직렬화 에러를 막기 위해 일반 PageImpl 대신 커스텀 RestPageImpl 객체에 담아 반환!
+        return new RestPageImpl<>(content, page.getNumber(), page.getSize(), page.getTotalElements());
     }
 
-    // 점주/관리자용 - 상태 상관없이 전체 상품 조회
+    // 점주/관리자용 - 상태 상관없이 전체 상품 조회 (캐시 없음)
     public Page<ProductViewResponse> getAllProducts(Pageable pageable) {
         return productViewRepository.findAll(pageable)
             .map(ProductViewResponse::from);

--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -25,8 +25,12 @@ public class ProductViewQueryService {
     private final ProductViewRepository productViewRepository;
 
     // 고객용 - 노출 중인 상품만 조회
-    // Cache-Aside 패턴 도입: 페이지 번호 단위로 독립적 캐시 생성 관리
-    @Cacheable(value = "products_cache", key = "#pageable.pageNumber", cacheManager = "catalogCacheManager")
+    // Cache-Aside 패턴 도입: 페이지 번호 단위로 독립적 캐시 생성 관리 - 페이지 크기와 정렬 조건을 캐시 키에 포함하여 충돌 방지
+    @Cacheable(
+        value = "products_cache",
+        key = "T(java.lang.String).format('%d-%d-%s', #pageable.pageNumber, #pageable.pageSize, #pageable.sort.toString())",
+        cacheManager = "catalogCacheManager"
+    )
     public Page<ProductViewResponse> getActiveProducts(Pageable pageable) {
         log.info("[Cache Miss] 몽고DB로 직행하여 노출 상품 목록 조회 활성화 - Page: {}", pageable.getPageNumber());
 

--- a/src/main/java/com/michelet/catalog/infrastructure/config/PerfDataInitializer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/PerfDataInitializer.java
@@ -12,7 +12,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
-import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -34,26 +33,35 @@ public class PerfDataInitializer implements ApplicationRunner {
 
         // 1. 부하테스트 주문 타겟 고정 데이터 삽입
         try {
-            ProductView.OptionView targetOption = new ProductView.OptionView(
-                TEST_OPTION_ID, "타겟 부하테스트 옵션", BigDecimal.ZERO,
-                1000000, 1000000, 1000000
-            );
-            ProductView targetProduct = ProductView.builder()
-                .productId(TEST_PRODUCT_ID) // 랜덤 UUID 대신 고정 ID 사용
-                .restaurantId(TEST_RESTAURANT_ID)
-                .name("타겟 부하테스트 상품")
-                .category("MEALKIT")
-                .status("ACTIVE")
-                .basePrice(BigDecimal.valueOf(10000))
-                .isVisible(true)
-                .display(new ProductView.Display(LocalDateTime.now(), LocalDateTime.now().plusYears(1)))
-                .options(List.of(targetOption))
-                .build();
-            productViewRepository.save(targetProduct);
-            log.info("[PerfDataInitializer] 카탈로그 타겟 고정 데이터(OptionId: {}) 세팅 완료", TEST_OPTION_ID);
-        } catch (DuplicateKeyException e) {
-            // 중복 키 에러만 잡아서 정상적인 로그로 넘김
-            log.info("[PerfDataInitializer] 타겟 데이터 이미 존재: {}", TEST_PRODUCT_ID);
+            // DB에 이미 타겟 데이터가 있는지 검사하여 중복 적재 차단!
+            boolean targetExists = false;
+            try {
+                targetExists = productViewRepository.findByProductId(TEST_PRODUCT_ID).isPresent();
+            } catch (org.springframework.dao.IncorrectResultSizeDataAccessException e) {
+                targetExists = true; // 이미 2개 이상 복제되어 있다면 존재하는 것으로 취급
+            }
+
+            if (!targetExists) {
+                ProductView.OptionView targetOption = new ProductView.OptionView(
+                    TEST_OPTION_ID, "타겟 부하테스트 옵션", BigDecimal.ZERO,
+                    1000000, 1000000, 1000000
+                );
+                ProductView targetProduct = ProductView.builder()
+                    .productId(TEST_PRODUCT_ID) // 랜덤 UUID 대신 고정 ID 사용
+                    .restaurantId(TEST_RESTAURANT_ID)
+                    .name("타겟 부하테스트 상품")
+                    .category("MEALKIT")
+                    .status("ACTIVE")
+                    .basePrice(BigDecimal.valueOf(10000))
+                    .isVisible(true)
+                    .display(new ProductView.Display(LocalDateTime.now(), LocalDateTime.now().plusYears(1)))
+                    .options(List.of(targetOption))
+                    .build();
+                productViewRepository.save(targetProduct);
+                log.info("[PerfDataInitializer] 카탈로그 타겟 고정 데이터(OptionId: {}) 세팅 완료", TEST_OPTION_ID);
+            } else {
+                log.info("[PerfDataInitializer] 타겟 데이터가 이미 존재하여 생략합니다: {}", TEST_PRODUCT_ID);
+            }
         } catch (Exception e) {
             // 그 외의 에러(DB 다운 등)는 삼키지 않고 던짐
             log.error("타겟 데이터 세팅 중 예상치 못한 에러 발생", e);

--- a/src/main/java/com/michelet/catalog/infrastructure/config/PerfDataInitializer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/PerfDataInitializer.java
@@ -12,6 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.ApplicationArguments;
 import org.springframework.boot.ApplicationRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -57,8 +58,14 @@ public class PerfDataInitializer implements ApplicationRunner {
                     .display(new ProductView.Display(LocalDateTime.now(), LocalDateTime.now().plusYears(1)))
                     .options(List.of(targetOption))
                     .build();
-                productViewRepository.save(targetProduct);
-                log.info("[PerfDataInitializer] 카탈로그 타겟 고정 데이터(OptionId: {}) 세팅 완료", TEST_OPTION_ID);
+
+                // TOCTOU 동시성 예외 방어를 위한 save 단위 try-catch
+                try {
+                    productViewRepository.save(targetProduct);
+                    log.info("[PerfDataInitializer] 카탈로그 타겟 고정 데이터(OptionId: {}) 세팅 완료", TEST_OPTION_ID);
+                } catch (DuplicateKeyException e) {
+                    log.info("[PerfDataInitializer] 동시 기동으로 인해 타겟 데이터가 이미 존재하여 생략합니다: {}", TEST_PRODUCT_ID);
+                }
             } else {
                 log.info("[PerfDataInitializer] 타겟 데이터가 이미 존재하여 생략합니다: {}", TEST_PRODUCT_ID);
             }

--- a/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
@@ -1,0 +1,50 @@
+package com.michelet.catalog.infrastructure.config;
+
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.time.Duration;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+@EnableCaching
+public class RedisCacheConfig {
+
+    @Bean
+    public CacheManager catalogCacheManager(RedisConnectionFactory connectionFactory) {
+        // 역직렬화 시 날짜 포맷 깨짐 방지 및 다형성 타입 보존을 위한 커스텀 ObjectMapper
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.activateDefaultTyping(
+            LaissezFaireSubTypeValidator.instance,
+            ObjectMapper.DefaultTyping.NON_FINAL,
+            JsonTypeInfo.As.PROPERTY
+        );
+
+        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
+            // 캐시 유효 시간 설정 (기본 1시간)
+            .entryTtl(Duration.ofHours(1))
+            // 캐시 Key는 String으로 직렬화
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            // 캐시 Value는 JSON 구조로 직렬화하여 가독성 및 호환성 보장
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
+            // 몽고DB의 데이터가 null일 경우 캐싱을 방지 (Cache Penetration 방어)
+            .disableCachingNullValues();
+
+        return RedisCacheManager.RedisCacheManagerBuilder
+            .fromConnectionFactory(connectionFactory)
+            .cacheDefaults(config)
+            .build();
+    }
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
@@ -2,7 +2,8 @@ package com.michelet.catalog.infrastructure.config;
 
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.jsontype.impl.LaissezFaireSubTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
+import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
@@ -25,13 +26,25 @@ public class RedisCacheConfig {
         // 역직렬화 시 날짜 포맷 깨짐 방지 및 다형성 타입 보존을 위한 커스텀 ObjectMapper
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
+
+        // 무방비 역직렬화 공격 차단을 위한 화이트리스트 보안 필터 적용
+        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
+            .allowIfSubType("com.michelet.catalog")
+            .allowIfSubType("org.springframework.data.domain")
+            .allowIfSubType("java.util")
+            .allowIfSubType("java.time")
+            .allowIfSubType("java.math")
+            .allowIfBaseType(Object.class)
+            .build();
+
         objectMapper.activateDefaultTyping(
-            LaissezFaireSubTypeValidator.instance,
+            ptv,
             ObjectMapper.DefaultTyping.NON_FINAL,
             JsonTypeInfo.As.PROPERTY
         );
 
         GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+
         RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
             // 캐시 유효 시간 설정 (기본 1시간)
             .entryTtl(Duration.ofHours(1))

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -6,6 +6,7 @@ import com.michelet.catalog.infrastructure.messaging.dto.ProductStatusChangedEve
 import com.michelet.catalog.infrastructure.messaging.dto.ProductUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,8 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.product-created:product.created}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    // 이벤트 유입 즉시 메인 화면 캐시 제거
     public void consumeProductCreatedEvent(ProductCreatedEvent event) {
         log.info("product.created 이벤트 수신: {}", event);
         productViewCommandService.createProductView(event);
@@ -30,6 +33,8 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.product-updated:product.updated}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    // 이벤트 유입 즉시 메인 화면 캐시 제거
     public void consumeProductUpdatedEvent(ProductUpdatedEvent event) {
         log.info("product.updated 이벤트 수신: {}", event);
         productViewCommandService.updateProductView(event);
@@ -40,6 +45,8 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.status-changed:product.status-changed}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    // 이벤트 유입 즉시 메인 화면 캐시 제거
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
         log.info("product.status-changed 이벤트 수신: {}", event);
         productViewCommandService.updateProductStatus(event);

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -6,6 +6,7 @@ import com.michelet.catalog.infrastructure.messaging.dto.StockReservedEvent;
 import com.michelet.catalog.infrastructure.messaging.dto.StockRestoredEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -20,6 +21,7 @@ public class StockEventConsumer {
         topics = "${catalog.kafka.topic.stock-reserved:stock.reserved}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager") // 재고 차감 시 캐시 초기화 트리거
     public void consumeStockReservedEvent(StockReservedEvent event) {
         log.info("stock.reserved 이벤트 수신: {}", event);
         // KafkaListener Container가 에러를 인지하고 재시도 할 수 있도록
@@ -30,6 +32,7 @@ public class StockEventConsumer {
         topics = "${catalog.kafka.topic.stock-restored:stock.restored}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager") // 재고 원복 시 캐시 초기화 트리거
     public void consumeStockRestoredEvent(StockRestoredEvent event) {
         log.info("stock.restored 이벤트 수신: {}", event);
         productViewCommandService.applyStockRestoredEvent(event);
@@ -40,6 +43,8 @@ public class StockEventConsumer {
         topics = "${catalog.kafka.topic.daily-reset:stock.daily-reset}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    // 자정 전수 스캔 초기화 시 캐시 전면 무효화
     public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
         log.info("stock.daily-reset 이벤트 수신: {}", event);
         productViewCommandService.resetAllDailyStocks(event);

--- a/src/main/java/com/michelet/catalog/presentation/dto/RestPageImpl.java
+++ b/src/main/java/com/michelet/catalog/presentation/dto/RestPageImpl.java
@@ -1,0 +1,21 @@
+package com.michelet.catalog.presentation.dto;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+// Redis 역직렬화 에러를 우회하기 위한 PageImpl 커스텀 래퍼
+@JsonIgnoreProperties(ignoreUnknown = true, value = {"pageable"})
+public class RestPageImpl<T> extends PageImpl<T> {
+
+    @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
+    public RestPageImpl(@JsonProperty("content") List<T> content,
+                        @JsonProperty("number") int number,
+                        @JsonProperty("size") int size,
+                        @JsonProperty("totalElements") Long totalElements) {
+        super(content, PageRequest.of(number, size == 0 ? 10 : size), totalElements == null ? 0 : totalElements);
+    }
+}

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -2,6 +2,10 @@ spring:
     data:
         mongodb:
             uri: mongodb://mongo-db:27017/michelet_catalog
+        # 도커 컨테이너 가상 네트워크 통신용 Redis 바인딩
+        redis:
+            host: redis
+            port: 6379
     kafka:
         bootstrap-servers: kafka:9092
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,6 +2,10 @@ spring:
     data:
         mongodb:
             uri: mongodb://localhost:27017/michelet_catalog
+        # 로컬 구동용 Redis 인프라 바인딩
+        redis:
+            host: localhost
+            port: 6379
     kafka:
         bootstrap-servers: localhost:9092
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,16 +16,9 @@ spring:
         hibernate:
             ddl-auto: create-drop
 
-    # JUnit 테스트 가동 시 프로덕션 캐시매니저 충돌 방지용 모킹 가이드 주입
-    data:
-        redis:
-            host: localhost
-            port: 6379
-
-    # 만약 MongoDB 관련 에러가 발생한다면 아래 설정을 추가
-    # data:
-    #   mongodb:
-    #     uri: mongodb://localhost:27017/test
+    # 테스트 실행 시 Redis 연결 시도로 인한 컨텍스트 붕괴 방지
+    cache:
+        type: none
 
 catalog:
     kafka:

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,6 +16,12 @@ spring:
         hibernate:
             ddl-auto: create-drop
 
+    # JUnit 테스트 가동 시 프로덕션 캐시매니저 충돌 방지용 모킹 가이드 주입
+    data:
+        redis:
+            host: localhost
+            port: 6379
+
     # 만약 MongoDB 관련 에러가 발생한다면 아래 설정을 추가
     # data:
     #   mongodb:


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 카탈로그 조회에 레디스 캐시 도입
- 재고 등 변화 발생 시 바로 초기화

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #21    \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="681" height="266" alt="스크린샷 2026-05-17 오전 12 52 44" src="https://github.com/user-attachments/assets/6a2f6074-9e59-41ba-a69d-9913f1dfe6cb" />
<img width="712" height="257" alt="스크린샷 2026-05-17 오전 12 53 03" src="https://github.com/user-attachments/assets/9248d391-17cb-4bf7-86f8-8b1ef6339b2a" />
<img width="1249" height="198" alt="스크린샷 2026-05-17 오전 12 54 01" src="https://github.com/user-attachments/assets/6be6a1a0-62d9-42d9-9473-392f60c66707" />
<img width="1305" height="103" alt="스크린샷 2026-05-17 오전 12 54 57" src="https://github.com/user-attachments/assets/694df28c-0d31-4bf7-a45a-d45ae94bf5e8" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 제품 목록 조회 성능 개선을 위한 Redis 기반 캐싱 추가
  * 제품·재고 변경 시 리스트 캐시 자동 무효화 및 동기화 적용

* **Tests**
  * 캐시 일관성·주문 연동 흐름을 검증하는 신규 시나리오(동적 값 추출 포함) 추가

* **Chores**
  * 캐시 관련 의존성 및 로컬/도커 환경 설정 추가/갱신
  * 테스트 실행용 캐시 비활성화 설정 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/catalog-service/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->