### PR TITLE
feat/26 - 카탈로그 db 업데이트 조건 수정, ShedLock

### DIFF
--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -303,7 +303,7 @@ Authorization: Bearer {{cat_user_token}}
     });
 %}
 
-### 0. 자정 스케줄러 지연 동기화 [사전 준비] 품절 테스트를 위한 재고 2개짜리 신규 상품 등록 (OWNER)
+### 0. 일일 스케줄러 지연 동기화 [사전 준비] 품절 테스트를 위한 재고 2개짜리 신규 상품 등록 (OWNER)
 POST http://{{host}}:{{gatewayPort}}/api/v1/products
 Content-Type: application/json
 Authorization: Bearer {{cat_owner_token}}
@@ -378,7 +378,7 @@ Authorization: Bearer {{cat_user_token}}
 %}
 
 
-### 3. [자정 배치 트리거] 시간이 흘러 자정이 되었다고 가정하고 스케줄러 강제 실행
+### 3-1. [일일 배치 트리거] 시간이 흘러 새로운 날이 되었다고 가정하고 스케줄러 강제 실행
 POST http://localhost:19800/internal/scheduler/trigger-visibility
 Accept: application/json
 X-Internal-Token: {{cat_internal_token}}
@@ -386,21 +386,33 @@ X-Internal-Token: {{cat_internal_token}}
 > {%
     client.test("배치 트리거 성공", function () {
         client.assert(response.status === 200, "트리거 실패");
-        client.log("자정 스케줄러 강제 구동 완료");
+        client.log("일일 스케줄러 강제 구동 완료");
+    });
+%}
+
+### 3-2. [일일 배치 트리거] 시간이 흘러 새로운 날이 되었다고 가정하고 스케줄러 강제 실행
+POST http://localhost:19801/internal/scheduler/trigger-visibility
+Accept: application/json
+X-Internal-Token: {{cat_internal_token}}
+
+> {%
+    client.test("배치 트리거 성공", function () {
+        client.assert(response.status === 200, "트리거 실패");
+        client.log("일일 스케줄러 강제 구동 완료");
     });
 %}
 
 
-### 4. [최종 확인] 자정 배치 이후 상품 단건 조회 검증
+### 4. [최종 확인] 일일 배치 이후 상품 단건 조회 검증
 # 스케줄러가 돌았으므로, 이제서야 'isVisible'이 false로 변해야 함
 GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{test26_product_id}}
 Accept: application/json
 Authorization: Bearer {{cat_user_token}}
 
 > {%
-    client.test("자정 배치 이후 노출 상태 변경 확인", function () {
+    client.test("일일 배치 이후 노출 상태 변경 확인", function () {
         var data = response.body.data ? response.body.data : response.body;
-        client.assert(data.isVisible === false, "[실패] 자정 배치가 돌았는데도 isVisible이 여전히 true임");
-        client.log("[최종 성공] 자정 배치가 돌면서 isVisible이 false로 완벽하게 업데이트 됨!");
+        client.assert(data.isVisible === false, "[실패] 일일 배치가 돌았는데도 isVisible이 여전히 true임");
+        client.log("[최종 성공] 일일 배치가 돌면서 isVisible이 false로 완벽하게 업데이트 됨!");
     });
 %}

--- a/api-test/catalog.http
+++ b/api-test/catalog.http
@@ -302,3 +302,105 @@ Authorization: Bearer {{cat_user_token}}
         client.log("[성공] 하드코딩 없이 동적 변수로 캐시 무효화 정합성 증명 완료!");
     });
 %}
+
+### 0. 자정 스케줄러 지연 동기화 [사전 준비] 품절 테스트를 위한 재고 2개짜리 신규 상품 등록 (OWNER)
+POST http://{{host}}:{{gatewayPort}}/api/v1/products
+Content-Type: application/json
+Authorization: Bearer {{cat_owner_token}}
+
+{
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "name": "지연 동기화 테스트 한정판 밀키트",
+    "category": "MEALKIT",
+    "basePrice": 50000,
+    "attributes": {},
+    "exhibition": {
+        "startAt": "2024-01-01T00:00:00",
+        "endAt": "2099-12-31T23:59:59"
+    },
+    "options": [
+        { "name": "한정판 단일 옵션", "addPrice": 0, "totalQuantity": 2, "dailyLimit": 2, "maxLimit": 2 }
+    ]
+}
+
+> {%
+    client.test("테스트용 상품 등록 성공", function () {
+        client.assert(response.status === 200, "상품 등록 실패");
+        client.global.set("test26_product_id", response.body.data.productId);
+        client.global.set("test26_option_id", response.body.data.options[0].optionId);
+        client.log("테스트용 신규 상품 생성 완료! Option ID: " + client.global.get("test26_option_id"));
+    });
+%}
+
+
+### 1. [품절 발생] 등록한 상품의 재고(2개)를 전부 주문하여 SOLDOUT 유발 (USER)
+POST http://{{host}}:{{gatewayPort}}/api/v1/orders
+Content-Type: application/json
+Authorization: Bearer {{cat_user_token}}
+
+{
+    "reservationId": "{{$random.uuid}}",
+    "restaurantId": "{{dummy_restaurant_id}}",
+    "orderName": "전체 품절 유발 주문",
+    "receivingMethod": "PICKUP",
+    "expiredAt": "2099-12-31T23:59:59",
+    "items": [
+        { "optionId": "{{test26_option_id}}", "quantity": 2 }
+    ]
+}
+
+> {%
+    client.test("전체 수량 주문 성공", function () {
+        client.assert(response.status === 201, "주문 실패");
+        client.log("2개 전체 주문 완료! 카프카로 품절 이벤트가 전파됨");
+    });
+%}
+
+
+### 2. [지연 동기화 확인] 품절 직후 상품 단건 조회 검증
+# 상태는 'SOLDOUT'으로 변해야 하지만, 'isVisible'은 여전히 true여야 함!
+< {%
+    client.log("카프카 이벤트 전파를 위해 3초 대기 (버전 호환성 보장 로직)...");
+    var start = new Date().getTime();
+    while (new Date().getTime() < start + 3000) ;
+%}
+GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{test26_product_id}}
+Accept: application/json
+Authorization: Bearer {{cat_user_token}}
+
+> {%
+    client.test("품절 직후 노출 상태 지연 유지 확인", function () {
+        var data = response.body.data ? response.body.data : response.body;
+        client.assert(data.status === "SOLDOUT", "상태가 SOLDOUT이 아님. 현재: " + data.status);
+        client.assert(data.isVisible === true, "[실패] 품절되자마자 isVisible이 false로 바뀜 - 지연 동기화 실패!");
+        client.log("[1차 성공] 품절 상태(SOLDOUT)가 되었지만 화면 노출(isVisible: true)은 안전하게 유지되고 있음!");
+    });
+%}
+
+
+### 3. [자정 배치 트리거] 시간이 흘러 자정이 되었다고 가정하고 스케줄러 강제 실행
+POST http://localhost:19800/internal/scheduler/trigger-visibility
+Accept: application/json
+X-Internal-Token: {{cat_internal_token}}
+
+> {%
+    client.test("배치 트리거 성공", function () {
+        client.assert(response.status === 200, "트리거 실패");
+        client.log("자정 스케줄러 강제 구동 완료");
+    });
+%}
+
+
+### 4. [최종 확인] 자정 배치 이후 상품 단건 조회 검증
+# 스케줄러가 돌았으므로, 이제서야 'isVisible'이 false로 변해야 함
+GET http://{{host}}:{{gatewayPort}}/api/v1/products/{{test26_product_id}}
+Accept: application/json
+Authorization: Bearer {{cat_user_token}}
+
+> {%
+    client.test("자정 배치 이후 노출 상태 변경 확인", function () {
+        var data = response.body.data ? response.body.data : response.body;
+        client.assert(data.isVisible === false, "[실패] 자정 배치가 돌았는데도 isVisible이 여전히 true임");
+        client.log("[최종 성공] 자정 배치가 돌면서 isVisible이 false로 완벽하게 업데이트 됨!");
+    });
+%}

--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,12 @@ dependencies {
     testImplementation 'org.testcontainers:junit-jupiter'
 
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // ShedLock core + Spring 연동
+    implementation 'net.javacrumbs.shedlock:shedlock-spring:7.7.0'
+    // Redis Provider
+    implementation 'net.javacrumbs.shedlock:shedlock-provider-redis-spring:7.7.0'
+
 }
 
 dependencyManagement {

--- a/src/main/java/com/michelet/catalog/CatalogServiceApplication.java
+++ b/src/main/java/com/michelet/catalog/CatalogServiceApplication.java
@@ -2,6 +2,7 @@ package com.michelet.catalog;
 
 import static org.springframework.data.web.config.EnableSpringDataWebSupport.PageSerializationMode.VIA_DTO;
 
+import com.michelet.common.auth.webmvc.aop.AuthorizationAspect;
 import com.michelet.common.config.CommonAutoConfiguration;
 import com.michelet.common.exception.GlobalExceptionHandler;
 import org.springframework.boot.SpringApplication;
@@ -11,6 +12,7 @@ import org.springframework.boot.autoconfigure.jdbc.DataSourceTransactionManagerA
 import org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.web.config.EnableSpringDataWebSupport;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 // 공통 모듈(common)에서 가져온 JPA 때문에 발생하는 불필요한 RDBMS 자동 설정 비활성화
 @SpringBootApplication(exclude = {
@@ -20,7 +22,8 @@ import org.springframework.data.web.config.EnableSpringDataWebSupport;
     CommonAutoConfiguration.class // 공통 모듈의 자동 설정(JPA Auditing 포함) 비활성화
 })
 @EnableSpringDataWebSupport(pageSerializationMode = VIA_DTO)
-@Import(GlobalExceptionHandler.class) // 공통 모듈에서 필요한 전역 예외 처리기만 수동으로 등록
+@Import({GlobalExceptionHandler.class, AuthorizationAspect.class}) // 공통 모듈에서 필요한 전역 예외 처리기만 수동으로 등록
+@EnableScheduling
 public class CatalogServiceApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
+++ b/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
@@ -6,6 +6,9 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.cache.Cache;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
@@ -20,62 +23,79 @@ import org.springframework.stereotype.Service;
 public class CatalogVisibilityScheduler {
 
     private final ProductViewRepository productViewRepository;
+    private final CacheManager catalogCacheManager;
 
-    // 매일 자정(00:00:00)에 실행되며 캐시를 한 번에 폭파함
-    // beforeInvocation=true 옵션 추가 (배치 실패 시 캐시 불일치 방지)
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    // 매일 새벽 12시 25분(00:25:00)에 실행. beforeInvocation=true로 실행 직전 1차 캐시 비움
+    @Scheduled(cron = "0 25 0 * * *", zone = "Asia/Seoul")
+    // 다중 인스턴스 환경에서 스케줄러 중복 실행 방지 (ShedLock)
+    @SchedulerLock(
+        name = "syncVisibilityAtMidnight",
+        lockAtLeastFor = "PT5M", // 작업이 5분 내로 끝나도 락을 5분간 유지
+        lockAtMostFor = "PT25M" // 25분 후 Redis에서 자동으로 락을 해제
+    )
     @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager", beforeInvocation = true)
     public void syncVisibilityAtMidnight() {
-        log.info("[Catalog Batch] 자정 isVisible 일괄 동기화 스케줄러 시작");
+        log.info("[Catalog Batch] 일일 isVisible 일괄 동기화 스케줄러 시작");
 
-        int pageSize = 500;
-        // OOM 방지를 위해 500건씩 청크 단위로 나누어 스캔 (productId 오름차순 정렬)
-        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.ASC, "productId"));
-        Page<ProductView> page;
         int totalUpdated = 0;
 
-        do {
-            page = productViewRepository.findAll(pageRequest);
-            if (page.isEmpty()) {
-                break;
-            }
+        try {
+            int pageSize = 500;
+            // OOM 방지를 위해 500건씩 청크 단위로 나누어 스캔 (productId 오름차순 정렬)
+            PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.ASC, "productId"));
+            Page<ProductView> page;
 
-            List<ProductView> batch = page.getContent();
-            List<ProductView> updateBatch = new ArrayList<>();
-
-            for (ProductView product : batch) {
-                // ACTIVE 상태인 상품만 true, 나머지는 false여야 함
-                boolean targetVisibility = "ACTIVE".equals(product.getStatus());
-
-                // 실제 노출 상태와 목표 상태가 다를 때만 업데이트 대상에 추가
-                if (product.isVisible() != targetVisibility) {
-                    product.updateVisibility(targetVisibility);
-                    updateBatch.add(product);
+            do {
+                page = productViewRepository.findAll(pageRequest);
+                if (page.isEmpty()) {
+                    break;
                 }
-            }
 
-            // 변경된 데이터만 선별하여 MongoDB에 저장 (낙관적 락 충돌 폴백 처리 적용)
-            if (!updateBatch.isEmpty()) {
-                try {
-                    productViewRepository.saveAll(updateBatch);
-                    totalUpdated += updateBatch.size();
-                } catch (OptimisticLockingFailureException e) {
-                    log.warn("[Catalog Batch] 배치 저장 중 낙관적 락 충돌 발생. 단건 저장으로 폴백(Fallback)합니다.", e);
-                    for (ProductView product : updateBatch) {
-                        try {
-                            productViewRepository.save(product);
-                            totalUpdated++;
-                        } catch (Exception innerException) {
-                            log.error("[Catalog Batch] 상품 노출 상태 단건 업데이트 실패. productId: {}", product.getProductId(),
-                                innerException);
+                List<ProductView> batch = page.getContent();
+                List<ProductView> updateBatch = new ArrayList<>();
+
+                for (ProductView product : batch) {
+                    // ACTIVE 상태인 상품만 true, 나머지는 false여야 함
+                    boolean targetVisibility = "ACTIVE".equals(product.getStatus());
+
+                    // 실제 노출 상태와 목표 상태가 다를 때만 업데이트 대상에 추가
+                    if (product.isVisible() != targetVisibility) {
+                        product.updateVisibility(targetVisibility);
+                        updateBatch.add(product);
+                    }
+                }
+
+                // 변경된 데이터만 선별하여 MongoDB에 저장 (낙관적 락 충돌 폴백 처리 적용)
+                if (!updateBatch.isEmpty()) {
+                    try {
+                        productViewRepository.saveAll(updateBatch);
+                        totalUpdated += updateBatch.size();
+                    } catch (OptimisticLockingFailureException e) {
+                        log.warn("[Catalog Batch] 배치 저장 중 낙관적 락 충돌 발생. 단건 저장으로 폴백(Fallback)합니다.", e);
+                        for (ProductView product : updateBatch) {
+                            try {
+                                productViewRepository.save(product);
+                                totalUpdated++;
+                            } catch (Exception innerException) {
+                                log.error("[Catalog Batch] 상품 노출 상태 단건 업데이트 실패. productId: {}", product.getProductId(),
+                                    innerException);
+                            }
                         }
                     }
                 }
+
+                pageRequest = pageRequest.next();
+            } while (page.hasNext());
+
+            log.info("[Catalog Batch] 총 {}개의 상품 노출 상태(isVisible) 동기화 완료", totalUpdated);
+
+        } finally {
+            // 배치 실행 도중 유저 조회로 인해 오염되었을 수 있는 캐시를 마지막에 확실하게 정리
+            Cache cache = catalogCacheManager.getCache("products_cache");
+            if (cache != null) {
+                cache.clear();
+                log.info("[Catalog Batch] 배치 종료 후 products_cache 명시적 초기화 완료 (Stale 데이터 방지)");
             }
-
-            pageRequest = pageRequest.next();
-        } while (page.hasNext());
-
-        log.info("[Catalog Batch] 총 {}개의 상품 노출 상태(isVisible) 동기화 및 캐시 무효화 완료", totalUpdated);
+        }
     }
 }

--- a/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
+++ b/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
@@ -1,0 +1,66 @@
+package com.michelet.catalog.application;
+
+import com.michelet.catalog.domain.model.ProductView;
+import com.michelet.catalog.domain.repository.ProductViewRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CatalogVisibilityScheduler {
+
+    private final ProductViewRepository productViewRepository;
+
+    // 매일 자정(00:00:00)에 실행되며 캐시를 한 번에 폭파함
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    public void syncVisibilityAtMidnight() {
+        log.info("[Catalog Batch] 자정 isVisible 일괄 동기화 스케줄러 시작");
+
+        int pageSize = 500;
+        // OOM 방지를 위해 500건씩 청크 단위로 나누어 스캔 (productId 오름차순 정렬)
+        PageRequest pageRequest = PageRequest.of(0, pageSize, Sort.by(Sort.Direction.ASC, "productId"));
+        Page<ProductView> page;
+        int totalUpdated = 0;
+
+        do {
+            page = productViewRepository.findAll(pageRequest);
+            if (page.isEmpty()) {
+                break;
+            }
+
+            List<ProductView> batch = page.getContent();
+            List<ProductView> updateBatch = new ArrayList<>();
+
+            for (ProductView product : batch) {
+                // ACTIVE 상태인 상품만 true, 나머지는 false여야 함
+                boolean targetVisibility = "ACTIVE".equals(product.getStatus());
+
+                // 실제 노출 상태와 목표 상태가 다를 때만 업데이트 대상에 추가
+                if (product.isVisible() != targetVisibility) {
+                    product.updateVisibility(targetVisibility);
+                    updateBatch.add(product);
+                }
+            }
+
+            // 변경된 데이터만 선별하여 MongoDB에 저장
+            if (!updateBatch.isEmpty()) {
+                productViewRepository.saveAll(updateBatch);
+                totalUpdated += updateBatch.size();
+            }
+
+            pageRequest = pageRequest.next();
+        } while (page.hasNext());
+
+        log.info("[Catalog Batch] 총 {}개의 상품 노출 상태(isVisible) 동기화 및 캐시 무효화 완료", totalUpdated);
+    }
+}

--- a/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
+++ b/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
@@ -74,7 +74,15 @@ public class CatalogVisibilityScheduler {
                         log.warn("[Catalog Batch] 배치 저장 중 낙관적 락 충돌 발생. 단건 저장으로 폴백(Fallback)합니다.", e);
                         for (ProductView product : updateBatch) {
                             try {
-                                productViewRepository.save(product);
+                                // 최신 버전을 DB에서 다시 조회하여 업데이트 (Stale Entity 재사용 방지)
+                                productViewRepository.findByProductId(product.getProductId())
+                                    .ifPresent(freshProduct -> {
+                                        boolean targetVisibility = "ACTIVE".equals(freshProduct.getStatus());
+                                        if (freshProduct.isVisible() != targetVisibility) {
+                                            freshProduct.updateVisibility(targetVisibility);
+                                            productViewRepository.save(freshProduct);
+                                        }
+                                    });
                                 totalUpdated++;
                             } catch (Exception innerException) {
                                 log.error("[Catalog Batch] 상품 노출 상태 단건 업데이트 실패. productId: {}", product.getProductId(),

--- a/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
+++ b/src/main/java/com/michelet/catalog/application/CatalogVisibilityScheduler.java
@@ -7,6 +7,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -21,8 +22,9 @@ public class CatalogVisibilityScheduler {
     private final ProductViewRepository productViewRepository;
 
     // 매일 자정(00:00:00)에 실행되며 캐시를 한 번에 폭파함
+    // beforeInvocation=true 옵션 추가 (배치 실패 시 캐시 불일치 방지)
     @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
-    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager", beforeInvocation = true)
     public void syncVisibilityAtMidnight() {
         log.info("[Catalog Batch] 자정 isVisible 일괄 동기화 스케줄러 시작");
 
@@ -52,10 +54,23 @@ public class CatalogVisibilityScheduler {
                 }
             }
 
-            // 변경된 데이터만 선별하여 MongoDB에 저장
+            // 변경된 데이터만 선별하여 MongoDB에 저장 (낙관적 락 충돌 폴백 처리 적용)
             if (!updateBatch.isEmpty()) {
-                productViewRepository.saveAll(updateBatch);
-                totalUpdated += updateBatch.size();
+                try {
+                    productViewRepository.saveAll(updateBatch);
+                    totalUpdated += updateBatch.size();
+                } catch (OptimisticLockingFailureException e) {
+                    log.warn("[Catalog Batch] 배치 저장 중 낙관적 락 충돌 발생. 단건 저장으로 폴백(Fallback)합니다.", e);
+                    for (ProductView product : updateBatch) {
+                        try {
+                            productViewRepository.save(product);
+                            totalUpdated++;
+                        } catch (Exception innerException) {
+                            log.error("[Catalog Batch] 상품 노출 상태 단건 업데이트 실패. productId: {}", product.getProductId(),
+                                innerException);
+                        }
+                    }
+                }
             }
 
             pageRequest = pageRequest.next();

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -168,8 +168,16 @@ public class ProductView {
         }
 
         this.status = status;
-        // 상태가 ACTIVE가 아니면 노출 여부(isVisible)도 자동으로 관리
-        this.isVisible = "ACTIVE".equals(status);
+
+        // 품절(SOLDOUT) 상태일 때는 실시간으로 노출 여부를 끄지 않고 스케줄러가 처리하도록 지연시킴
+        if (!"SOLDOUT".equals(status)) {
+            this.isVisible = "ACTIVE".equals(status);
+        }
+    }
+
+    // 자정 배치 스케줄러가 일괄로 노출 상태를 업데이트할 때 사용할 전용 메서드
+    public void updateVisibility(boolean isVisible) {
+        this.isVisible = isVisible;
     }
 
     // 상품 부분 업데이트 로직

--- a/src/main/java/com/michelet/catalog/domain/model/ProductView.java
+++ b/src/main/java/com/michelet/catalog/domain/model/ProductView.java
@@ -175,7 +175,7 @@ public class ProductView {
         }
     }
 
-    // 자정 배치 스케줄러가 일괄로 노출 상태를 업데이트할 때 사용할 전용 메서드
+    // 일일 배치 스케줄러가 일괄로 노출 상태를 업데이트할 때 사용할 전용 메서드
     public void updateVisibility(boolean isVisible) {
         this.isVisible = isVisible;
     }

--- a/src/main/java/com/michelet/catalog/infrastructure/config/ShedLockConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/ShedLockConfig.java
@@ -1,0 +1,25 @@
+package com.michelet.catalog.infrastructure.config;
+
+import net.javacrumbs.shedlock.core.LockProvider;
+import net.javacrumbs.shedlock.provider.redis.spring.RedisLockProvider;
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+@Configuration
+// order = 0 으로 설정하여 @CacheEvict 보다 먼저 락을 획득하도록 강제!
+// - 이렇게 해야 락을 획득한 딱 1대의 서버만 @CacheEvict를 실행할 수 있음
+@EnableSchedulerLock(
+    defaultLockAtMostFor = "PT30M", // 30분이 지나면 Redis에서 자동으로 락을 해제하여 다음 실행이 가능하게 함
+    order = 0
+)
+public class ShedLockConfig {
+
+    // ShedLock이 자물쇠 정보를 어디에 저장할지를 결정
+    @Bean
+    public LockProvider lockProvider(RedisConnectionFactory connectionFactory) {
+        // Redis를 이용해 'catalog-service-lock'이라는 이름의 글로벌 자물쇠 환경 구성
+        return new RedisLockProvider(connectionFactory, "catalog-service-lock");
+    }
+}

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -45,7 +45,12 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.status-changed:product.status-changed}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
-    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    @CacheEvict(
+        value = "products_cache",
+        allEntries = true,
+        condition = "#event.newStatus() != 'SOLDOUT'",
+        cacheManager = "catalogCacheManager"
+    )
     // 이벤트 유입 즉시 메인 화면 캐시 제거
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
         log.info("product.status-changed 이벤트 수신: {}", event);

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -51,7 +51,7 @@ public class ProductEventConsumer {
         condition = "#event.newStatus() != 'SOLDOUT'",
         cacheManager = "catalogCacheManager"
     )
-    // 이벤트 유입 즉시 메인 화면 캐시 제거
+    // SOLDOUT 이외 상태 변경 이벤트 유입 시 메인 화면 캐시 제거
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
         log.info("product.status-changed 이벤트 수신: {}", event);
         productViewCommandService.updateProductStatus(event);

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -44,7 +44,7 @@ public class StockEventConsumer {
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
     @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
-    // 자정 전수 스캔 초기화 시에만 캐시 전면 무효화
+    // 일일 전수 스캔 초기화 시에만 캐시 전면 무효화
     public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
         log.info("stock.daily-reset 이벤트 수신: {}", event);
         productViewCommandService.resetAllDailyStocks(event);

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/StockEventConsumer.java
@@ -21,7 +21,7 @@ public class StockEventConsumer {
         topics = "${catalog.kafka.topic.stock-reserved:stock.reserved}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
-    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager") // 재고 차감 시 캐시 초기화 트리거
+    // @CacheEvict 제거 - 재고가 차감되어도 메인 화면 캐시는 유지하여 조회 성능 극대화
     public void consumeStockReservedEvent(StockReservedEvent event) {
         log.info("stock.reserved 이벤트 수신: {}", event);
         // KafkaListener Container가 에러를 인지하고 재시도 할 수 있도록
@@ -32,7 +32,7 @@ public class StockEventConsumer {
         topics = "${catalog.kafka.topic.stock-restored:stock.restored}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
-    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager") // 재고 원복 시 캐시 초기화 트리거
+    // @CacheEvict 제거 - 재고가 복구되어도 캐시 유지
     public void consumeStockRestoredEvent(StockRestoredEvent event) {
         log.info("stock.restored 이벤트 수신: {}", event);
         productViewCommandService.applyStockRestoredEvent(event);
@@ -44,7 +44,7 @@ public class StockEventConsumer {
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
     @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
-    // 자정 전수 스캔 초기화 시 캐시 전면 무효화
+    // 자정 전수 스캔 초기화 시에만 캐시 전면 무효화
     public void consumeDailyStockResetEvent(DailyStockResetEvent event) {
         log.info("stock.daily-reset 이벤트 수신: {}", event);
         productViewCommandService.resetAllDailyStocks(event);

--- a/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
+++ b/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
@@ -12,7 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/internal/scheduler")
 @RequiredArgsConstructor
-@Profile("!prod")
+@Profile({"local", "test", "perf"})
 public class CatalogSchedulerTriggerController {
 
     private final CatalogVisibilityScheduler catalogVisibilityScheduler;

--- a/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
+++ b/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
@@ -1,0 +1,26 @@
+package com.michelet.catalog.presentation;
+
+import com.michelet.catalog.application.CatalogVisibilityScheduler;
+import com.michelet.common.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/internal/scheduler")
+@RequiredArgsConstructor
+@Profile("!prod")
+public class CatalogSchedulerTriggerController {
+
+    private final CatalogVisibilityScheduler catalogVisibilityScheduler;
+
+    // 자정 노출 동기화 스케줄러 강제 갱신 버튼 - 테스트용!
+    @PostMapping("/trigger-visibility")
+    public ResponseEntity<ApiResponse<String>> triggerVisibility() {
+        catalogVisibilityScheduler.syncVisibilityAtMidnight();
+        return ResponseEntity.ok(ApiResponse.ok("카탈로그 자정 노출 동기화 스케줄러 작동 완료 (캐시 무효화됨)"));
+    }
+}

--- a/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
+++ b/src/main/java/com/michelet/catalog/presentation/CatalogSchedulerTriggerController.java
@@ -17,10 +17,10 @@ public class CatalogSchedulerTriggerController {
 
     private final CatalogVisibilityScheduler catalogVisibilityScheduler;
 
-    // 자정 노출 동기화 스케줄러 강제 갱신 버튼 - 테스트용!
+    // 매일 밤 12시 25분 노출 동기화 스케줄러 강제 갱신 버튼 - 테스트용!
     @PostMapping("/trigger-visibility")
     public ResponseEntity<ApiResponse<String>> triggerVisibility() {
         catalogVisibilityScheduler.syncVisibilityAtMidnight();
-        return ResponseEntity.ok(ApiResponse.ok("카탈로그 자정 노출 동기화 스케줄러 작동 완료 (캐시 무효화됨)"));
+        return ResponseEntity.ok(ApiResponse.ok("카탈로그 일일 노출 동기화 스케줄러 작동 완료 (캐시 무효화됨)"));
     }
 }


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 기존에는 인벤토리에서 재고 관련 이벤트를 실시간으로 받고 실시간으로 반영했음
- 이를 읽기 db의 특성에 맞게, 실시간 -> 일일 업데이트 로 변경
- (따라서 현재는 Soldout된 것들도 일일 업데이트 이전까지는 카탈로그에서 같이 조회됩니다.)

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #26   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="892" height="582" alt="스크린샷 2026-05-17 오전 4 08 54" src="https://github.com/user-attachments/assets/40984629-dd8a-402c-86f5-2a488904397e" />
<img width="915" height="577" alt="스크린샷 2026-05-17 오전 4 09 12" src="https://github.com/user-attachments/assets/3441a66e-a377-4cec-be25-5f7a0b2f00ec" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 자정 배치로 상품 노출(isVisible)을 일괄 동기화하는 스케줄 도입
  * 내부 API로 배치 동기화를 수동 트리거 가능(개발/테스트 환경)

* **변경 사항**
  * 품절(SOLDOUT) 시 즉시 노출 상태 자동 변경을 보류하도록 동작 변경(자정 배치로 반영)
  * 재고/상태 이벤트 처리 시 불필요한 전체 캐시 무효화 감소

* **테스트**
  * 자정 동기화 지연 시나리오 검증용 테스트 시나리오 추가

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/catalog-service/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->