### PR TITLE
refactor/45 - 단건검증에도 캐시 도입

### DIFF
--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -57,6 +57,11 @@ public class ProductViewQueryService {
     }
 
     // 내부 통신용 옵션 유효성 검증 로직
+    @Cacheable(
+        value = "product_detail_cache",
+        key = "#optionId",
+        cacheManager = "catalogCacheManager"
+    )
     public OptionValidationResponse validateOptionInternal(UUID optionId) {
         // 1. 해당 옵션을 포함하는 상품 뷰 조회 (없으면 예외)
         ProductView productView = productViewRepository.findByOptionId(optionId)

--- a/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
+++ b/src/main/java/com/michelet/catalog/application/ProductViewQueryService.java
@@ -58,7 +58,7 @@ public class ProductViewQueryService {
 
     // 내부 통신용 옵션 유효성 검증 로직
     @Cacheable(
-        value = "product_detail_cache",
+        value = "product_validate_cache",
         key = "#optionId",
         cacheManager = "catalogCacheManager"
     )

--- a/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
@@ -4,7 +4,10 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.michelet.catalog.presentation.dto.OptionValidationResponse;
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.context.annotation.Bean;
@@ -13,6 +16,7 @@ import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -22,36 +26,54 @@ public class RedisCacheConfig {
 
     @Bean
     public CacheManager catalogCacheManager(RedisConnectionFactory connectionFactory) {
-        // 역직렬화 시 날짜 포맷 깨짐 방지 및 다형성 타입 보존을 위한 커스텀 ObjectMapper
-        ObjectMapper objectMapper = new ObjectMapper();
-        objectMapper.registerModule(new JavaTimeModule());
-        objectMapper.activateDefaultTyping(
+
+        // 다형성 타입이 필요한 캐시용 (products_cache 등)
+        ObjectMapper polymorphicMapper = new ObjectMapper();
+        polymorphicMapper.registerModule(new JavaTimeModule());
+        polymorphicMapper.activateDefaultTyping(
             BasicPolymorphicTypeValidator.builder()
                 .allowIfSubType("com.michelet")
                 .allowIfSubType("org.springframework.data.domain")
-                .allowIfSubType("java.util")
-                .allowIfSubType("java.time")
-                .allowIfSubType("java.math")
+                .allowIfSubType("java.util")       // 컬렉션 타입 허용 필수
+                .allowIfSubType("java.time")       // LocalDateTime 등 날짜 타입
+                .allowIfSubType("java.math")       // BigDecimal 등
                 .build(),
-            ObjectMapper.DefaultTyping.EVERYTHING,  // NON_FINAL → EVERYTHING으로 변경
+            ObjectMapper.DefaultTyping.NON_FINAL,
             JsonTypeInfo.As.PROPERTY
         );
+        GenericJackson2JsonRedisSerializer polymorphicSerializer =
+            new GenericJackson2JsonRedisSerializer(polymorphicMapper);
 
-        GenericJackson2JsonRedisSerializer serializer = new GenericJackson2JsonRedisSerializer(objectMapper);
+        // 타입 정보 불필요한 단순 DTO용 (product_validate_cache)
+        // OptionValidationResponse는 UUID/String/BigDecimal만 있어 @class 불필요
+        Jackson2JsonRedisSerializer<OptionValidationResponse> validateSerializer =
+            new Jackson2JsonRedisSerializer<>(OptionValidationResponse.class);
 
-        RedisCacheConfiguration config = RedisCacheConfiguration.defaultCacheConfig()
-            // 캐시 유효 시간 설정 (기본 1시간)
+        // 기본 설정 (products_cache 등에 적용)
+        RedisCacheConfiguration defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
             .entryTtl(Duration.ofHours(1))
-            // 캐시 Key는 String으로 직렬화
-            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-            // 캐시 Value는 JSON 구조로 직렬화하여 가독성 및 호환성 보장
-            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(serializer))
-            // 몽고DB의 데이터가 null일 경우 캐싱을 방지 (Cache Penetration 방어)
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(polymorphicSerializer))
             .disableCachingNullValues();
+
+        // product_validate_cache 전용 설정
+        RedisCacheConfiguration validateConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .entryTtl(Duration.ofHours(1))
+            .serializeKeysWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
+            .serializeValuesWith(
+                RedisSerializationContext.SerializationPair.fromSerializer(validateSerializer))
+            .disableCachingNullValues();
+
+        Map<String, RedisCacheConfiguration> cacheConfigs = new HashMap<>();
+        cacheConfigs.put("product_validate_cache", validateConfig);
 
         return RedisCacheManager.RedisCacheManagerBuilder
             .fromConnectionFactory(connectionFactory)
-            .cacheDefaults(config)
+            .cacheDefaults(defaultConfig)
+            .withInitialCacheConfigurations(cacheConfigs)
             .build();
     }
 }

--- a/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/config/RedisCacheConfig.java
@@ -3,7 +3,6 @@ package com.michelet.catalog.infrastructure.config;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.jsontype.BasicPolymorphicTypeValidator;
-import com.fasterxml.jackson.databind.jsontype.PolymorphicTypeValidator;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.Duration;
 import org.springframework.cache.CacheManager;
@@ -26,20 +25,15 @@ public class RedisCacheConfig {
         // 역직렬화 시 날짜 포맷 깨짐 방지 및 다형성 타입 보존을 위한 커스텀 ObjectMapper
         ObjectMapper objectMapper = new ObjectMapper();
         objectMapper.registerModule(new JavaTimeModule());
-
-        // 무방비 역직렬화 공격 차단을 위한 화이트리스트 보안 필터 적용
-        PolymorphicTypeValidator ptv = BasicPolymorphicTypeValidator.builder()
-            .allowIfSubType("com.michelet.catalog")
-            .allowIfSubType("org.springframework.data.domain")
-            .allowIfSubType("java.util")
-            .allowIfSubType("java.time")
-            .allowIfSubType("java.math")
-            .allowIfBaseType(Object.class)
-            .build();
-
         objectMapper.activateDefaultTyping(
-            ptv,
-            ObjectMapper.DefaultTyping.NON_FINAL,
+            BasicPolymorphicTypeValidator.builder()
+                .allowIfSubType("com.michelet")
+                .allowIfSubType("org.springframework.data.domain")
+                .allowIfSubType("java.util")
+                .allowIfSubType("java.time")
+                .allowIfSubType("java.math")
+                .build(),
+            ObjectMapper.DefaultTyping.EVERYTHING,  // NON_FINAL → EVERYTHING으로 변경
             JsonTypeInfo.As.PROPERTY
         );
 

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -37,7 +37,7 @@ public class ProductEventConsumer {
     @Caching(
         evict = {
             @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager"),
-            @CacheEvict(value = "product_detail_cache", allEntries = true, cacheManager = "catalogCacheManager")
+            @CacheEvict(value = "product_validate_cache", allEntries = true, cacheManager = "catalogCacheManager")
         }
     )
     // 이벤트 유입 즉시 메인 화면 캐시 제거
@@ -53,11 +53,13 @@ public class ProductEventConsumer {
     )
     @Caching(
         evict = {
+            // SOLDOUT 포함 모든 상태 변경 시에만 products_cache evict (목록 캐시는 조건부 유지)
             @CacheEvict(value = "products_cache", allEntries = true, condition = "#event.newStatus() != 'SOLDOUT'", cacheManager = "catalogCacheManager"),
-            @CacheEvict(value = "product_detail_cache", allEntries = true, condition = "#event.newStatus() != 'SOLDOUT'", cacheManager = "catalogCacheManager")
+            // 상태가 SOLDOUT으로 바뀌어도 단건 상세 캐시는 항상 evict (stale 옵션 검증 방지)
+            @CacheEvict(value = "product_validate_cache", allEntries = true, cacheManager = "catalogCacheManager")
         }
     )
-    // SOLDOUT 이외 상태 변경 이벤트 유입 시 메인 화면 캐시 제거
+    // SOLDOUT 이외 상태 변경 이벤트 유입 시 메인 화면 캐시 제거 / 상세 캐시는 항상 제거
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {
         log.info("product.status-changed 이벤트 수신: {}", event);
         productViewCommandService.updateProductStatus(event);

--- a/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
+++ b/src/main/java/com/michelet/catalog/infrastructure/messaging/ProductEventConsumer.java
@@ -7,6 +7,7 @@ import com.michelet.catalog.infrastructure.messaging.dto.ProductUpdatedEvent;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.stereotype.Component;
 
@@ -33,7 +34,12 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.product-updated:product.updated}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
-    @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager")
+    @Caching(
+        evict = {
+            @CacheEvict(value = "products_cache", allEntries = true, cacheManager = "catalogCacheManager"),
+            @CacheEvict(value = "product_detail_cache", allEntries = true, cacheManager = "catalogCacheManager")
+        }
+    )
     // 이벤트 유입 즉시 메인 화면 캐시 제거
     public void consumeProductUpdatedEvent(ProductUpdatedEvent event) {
         log.info("product.updated 이벤트 수신: {}", event);
@@ -45,11 +51,11 @@ public class ProductEventConsumer {
         topics = "${catalog.kafka.topic.status-changed:product.status-changed}",
         groupId = "${spring.kafka.consumer.group-id:catalog-service-consumer}"
     )
-    @CacheEvict(
-        value = "products_cache",
-        allEntries = true,
-        condition = "#event.newStatus() != 'SOLDOUT'",
-        cacheManager = "catalogCacheManager"
+    @Caching(
+        evict = {
+            @CacheEvict(value = "products_cache", allEntries = true, condition = "#event.newStatus() != 'SOLDOUT'", cacheManager = "catalogCacheManager"),
+            @CacheEvict(value = "product_detail_cache", allEntries = true, condition = "#event.newStatus() != 'SOLDOUT'", cacheManager = "catalogCacheManager")
+        }
     )
     // SOLDOUT 이외 상태 변경 이벤트 유입 시 메인 화면 캐시 제거
     public void consumeProductStatusChangedEvent(ProductStatusChangedEvent event) {


### PR DESCRIPTION
## 📝 작업 내용
> 이번 PR에서 작업한 내용을 설명해주세요.
- 주문 생성에서 사용되는 카탈로그 단건 검증에 캐시 도입

## 🚀 주요 변경 사항
> 완료한 이슈 번호 \
> Close #45   \
> 관련된 이슈 번호 (닫고 싶지 않은 경우) \
> Related to # 

## ✅ 자체 체크리스트 (필수)
- [x] `./gradlew build` 실행 결과 정상 (인증샷 첨부)
- [x] IntelliJ HTTP Client 테스트 완료 (인증샷 첨부)
- [x] 팀 내 컨벤션 준수 및 불필요한 로그, import 제거
- [x] 중요한 변경 사항이 팀에 공유되었는지

## 📸 테스트 인증샷
> 빌드 결과 및 IntelliJ HTTP Client 실행 화면을 여기에 첨부해 주세요.
<img width="530" height="303" alt="스크린샷 2026-05-18 오후 6 09 21" src="https://github.com/user-attachments/assets/f7a84986-1d85-432c-a6b2-41b7aa5b591e" />


## 💬 리뷰어 전달사항 (선택)
> 특별히 봐주었으면 하는 부분이나 논의가 필요한 점을 적어주세요.

<br>

---
## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **성능 개선**
  * 옵션 유효성 검증 결과를 옵션 단위로 캐싱해 조회 성능 향상
  * 상품 상세 캐시 직렬화 방식 개선으로 안정적 로딩 성능 향상

* **개선 사항**
  * 옵션 검증 전용 캐시 분리로 직렬화 안전성 강화
  * 상품 생성/업데이트/상태 변경 시 관련 캐시들을 보다 포괄적으로 동기화하여 데이터 일관성 개선

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Miche-Let/catalog-service/pull/46?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->